### PR TITLE
Show only allowed widgets for a certain main parameter

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -17,7 +17,7 @@ import useRefreshRateHandler from "./useRefreshRateHandler";
 import useEditModeHandler from "./useEditModeHandler";
 import useDuplicateDashboard from "./useDuplicateDashboard";
 import { policy } from "@/services/policy";
-
+import { getAllowedWidgetsForCurrentParam } from "./utils";
 export { DashboardStatusEnum } from "./useEditModeHandler";
 
 function getAffectedWidgets(widgets, updatedParameters = []) {
@@ -33,27 +33,6 @@ function getAffectedWidgets(widgets, updatedParameters = []) {
           )
       )
     : widgets;
-}
-
-function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets) {
-  try {
-    // filter the widgets by keeping only the ones we want
-    // get identifier of the current controller
-    for (var param of dashboardParameters) {
-      const controllerParam = param.value;
-      // check if we have allowed widgets for this param value
-      // get the allowed widgets for the current controller
-      if (dashboardAllowedWidgets.hasOwnProperty(controllerParam)) {
-        // filter the widgets to process
-        const allowedWidgetsIds = dashboardAllowedWidgets[controllerParam];
-        return dashboardAllWidgets.filter(widget => allowedWidgetsIds.includes(widget.id));
-      }
-    }
-  } catch (error) {
-    console.error(error);
-  }
-
-  return dashboardAllWidgets;
 }
 
 function useDashboard(dashboardData) {

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -131,11 +131,10 @@ function useDashboard(dashboardData) {
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
       // filter widgets to show from all the widgets according to the current parameters
-      dashboardRef.current.widgets = dashboardRef.current.saved_all_widgets;
       dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(
         dashboardRef.current.getParametersDefs(),
         dashboardRef.current.allowed_widgets,
-        dashboardRef.current.widgets
+        dashboardRef.current.saved_all_widgets
       );
 
       const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -130,12 +130,14 @@ function useDashboard(dashboardData) {
 
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
+      // filter widgets to show from all the widgets according to the current parameters
       dashboardRef.current.widgets = dashboardRef.current.saved_all_widgets;
       dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(
         dashboardRef.current.getParametersDefs(),
         dashboardRef.current.allowed_widgets,
         dashboardRef.current.widgets
       );
+
       const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
       const loadWidgetPromises = compact(
         affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -35,27 +35,25 @@ function getAffectedWidgets(widgets, updatedParameters = []) {
     : widgets;
 }
 
-function getAllowedWidgetsForCurrentParam(dashboard) {
+function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets) {
   try {
     // filter the widgets by keeping only the ones we want
     // get identifier of the current controller
-    const dashQueryParams = dashboard.getParametersDefs();
-    for (var param of dashQueryParams) {
+    for (var param of dashboardParameters) {
       const controllerParam = param.value;
       // check if we have allowed widgets for this param value
       // get the allowed widgets for the current controller
-      if (dashboard.allowed_widgets.hasOwnProperty(controllerParam)) {
+      if (dashboardAllowedWidgets.hasOwnProperty(controllerParam)) {
         // filter the widgets to process
-        const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
-        dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
-        break;
+        const allowedWidgetsIds = dashboardAllowedWidgets[controllerParam];
+        return dashboardAllWidgets.filter(widget => allowedWidgetsIds.includes(widget.id));
       }
     }
   } catch (error) {
     console.error(error);
   }
 
-  return dashboard.widgets;
+  return dashboardAllWidgets;
 }
 
 function useDashboard(dashboardData) {
@@ -154,7 +152,11 @@ function useDashboard(dashboardData) {
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
       dashboardRef.current.widgets = dashboardRef.current.saved_all_widgets;
-      dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(dashboardRef.current);
+      dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(
+        dashboardRef.current.getParametersDefs(),
+        dashboardRef.current.allowed_widgets,
+        dashboardRef.current.widgets
+      );
       const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
       const loadWidgetPromises = compact(
         affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -147,6 +147,7 @@ function useDashboard(dashboardData) {
 
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
+      dashboardRef.current.widgets = dashboardRef.current.saved_all_widgets;
       dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(dashboardRef.current);
       const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
       const loadWidgetPromises = compact(

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -40,11 +40,17 @@ function getAllowedWidgetsForCurrentParam(dashboard) {
     // filter the widgets by keeping only the ones we want
     // get identifier of the current controller
     const dashQueryParams = dashboard.getParametersDefs();
-    const controllerParam = dashQueryParams.filter(param => param.name === "controller_param")[0].value;
-    // get the allowed widgets for the current controller
-    const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
-    // filter the widgets to process
-    dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+    for (var param of dashQueryParams) {
+      const controllerParam = param.value;
+      // check if we have allowed widgets for this param value
+      // get the allowed widgets for the current controller
+      if (dashboard.allowed_widgets.hasOwnProperty(controllerParam)) {
+        // filter the widgets to process
+        const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
+        dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+        break;
+      }
+    }
   } catch (error) {
     console.error(error);
   }

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -35,6 +35,23 @@ function getAffectedWidgets(widgets, updatedParameters = []) {
     : widgets;
 }
 
+function getAllowedWidgetsForCurrentParam(dashboard) {
+  try {
+    // filter the widgets by keeping only the ones we want
+    // get identifier of the current controller
+    const dashQueryParams = dashboard.getParametersDefs();
+    const controllerParam = dashQueryParams.filter(param => param.name === "controller_param")[0].value;
+    // get the allowed widgets for the current controller
+    const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
+    // filter the widgets to process
+    dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+  } catch (error) {
+    console.error(error);
+  }
+
+  return dashboard.widgets;
+}
+
 function useDashboard(dashboardData) {
   const [dashboard, setDashboard] = useState(dashboardData);
   const [filters, setFilters] = useState([]);
@@ -130,6 +147,7 @@ function useDashboard(dashboardData) {
 
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
+      dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(dashboardRef.current);
       const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
       const loadWidgetPromises = compact(
         affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))

--- a/client/app/pages/dashboards/hooks/utils.js
+++ b/client/app/pages/dashboards/hooks/utils.js
@@ -1,15 +1,13 @@
 export function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets) {
   try {
     // filter the widgets by keeping only the ones we want
-    // get identifier of the current controller
     for (var param of dashboardParameters) {
-      const controllerParam = param.value;
+      const paramValue = param.value;
       // check if we have allowed widgets for this param value
-      // get the allowed widgets for the current controller
-      if (dashboardAllowedWidgets.hasOwnProperty(controllerParam)) {
+      if (dashboardAllowedWidgets !== undefined && dashboardAllowedWidgets.hasOwnProperty(paramValue)) {
         // filter the widgets to process
-        const allowedWidgetsIds = dashboardAllowedWidgets[controllerParam];
-        return dashboardAllWidgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+        const allowedWidgets = dashboardAllowedWidgets[paramValue];
+        return dashboardAllWidgets.filter(widget => allowedWidgets.includes(widget.visualization.name));
       }
     }
   } catch (error) {

--- a/client/app/pages/dashboards/hooks/utils.js
+++ b/client/app/pages/dashboards/hooks/utils.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 export function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets) {
   try {
     // filter the widgets by keeping only the ones we want
@@ -6,10 +8,29 @@ export function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardA
       // check if we have allowed widgets for this param value
       if (dashboardAllowedWidgets !== undefined && dashboardAllowedWidgets.hasOwnProperty(paramValue)) {
         // filter the widgets to process
-        const allowedWidgets = dashboardAllowedWidgets[paramValue];
-        return dashboardAllWidgets.filter(
-          widget => !widget.visualization || allowedWidgets.includes(widget.visualization.name)
-        );
+        let allowedWidgets = dashboardAllowedWidgets[paramValue];
+        allowedWidgets = allowedWidgets
+          .replace("[", "")
+          .replace("]", "")
+          .replaceAll("'", "")
+          .split(",");
+        let filtered_wgt_id = [];
+        for (let widget of dashboardAllWidgets) {
+          if (!widget.visualization) {
+            // if widget is a textbox - we show it
+            filtered_wgt_id.push(widget.id);
+          } else {
+            // if widget is not a textbox
+            // if the visualization name or any subset name in it is in allowedWidgets list - we show it
+            let listOfNames = widget.visualization.name.split(";");
+            listOfNames = _.union(listOfNames, [widget.visualization.name]);
+            if (_.intersection(allowedWidgets, listOfNames).length > 0) {
+              filtered_wgt_id.push(widget.id);
+            }
+          }
+        }
+        // we only consider one main parameter, this is why we return here
+        return dashboardAllWidgets.filter(widget => filtered_wgt_id.includes(widget.id));
       }
     }
   } catch (error) {

--- a/client/app/pages/dashboards/hooks/utils.js
+++ b/client/app/pages/dashboards/hooks/utils.js
@@ -7,7 +7,9 @@ export function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardA
       if (dashboardAllowedWidgets !== undefined && dashboardAllowedWidgets.hasOwnProperty(paramValue)) {
         // filter the widgets to process
         const allowedWidgets = dashboardAllowedWidgets[paramValue];
-        return dashboardAllWidgets.filter(widget => allowedWidgets.includes(widget.visualization.name));
+        return dashboardAllWidgets.filter(
+          widget => !widget.visualization || allowedWidgets.includes(widget.visualization.name)
+        );
       }
     }
   } catch (error) {

--- a/client/app/pages/dashboards/hooks/utils.js
+++ b/client/app/pages/dashboards/hooks/utils.js
@@ -1,0 +1,20 @@
+export function getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets) {
+  try {
+    // filter the widgets by keeping only the ones we want
+    // get identifier of the current controller
+    for (var param of dashboardParameters) {
+      const controllerParam = param.value;
+      // check if we have allowed widgets for this param value
+      // get the allowed widgets for the current controller
+      if (dashboardAllowedWidgets.hasOwnProperty(controllerParam)) {
+        // filter the widgets to process
+        const allowedWidgetsIds = dashboardAllowedWidgets[controllerParam];
+        return dashboardAllWidgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return dashboardAllWidgets;
+}

--- a/client/app/pages/dashboards/hooks/utils.test.js
+++ b/client/app/pages/dashboards/hooks/utils.test.js
@@ -8,8 +8,8 @@ describe("filterWidgets", () => {
       },
     ];
     let dashboardAllowedWidgets = {
-      controller12345: ["firstViz", "secondViz"],
-      "4d678ac-cdbc-49c4-ba0f-c8800bce5e8c": ["thirdViz"],
+      controller12345: "['firstViz','secondViz']",
+      "4d678ac-cdbc-49c4-ba0f-c8800bce5e8c": "['thirdViz']",
     };
     let dashboardAllWidgets = [
       { id: 1, visualization: { name: "firstViz" } },
@@ -40,8 +40,8 @@ describe("filterWidgets", () => {
       },
     ];
     let dashboardAllowedWidgets = {
-      "building kreuzberg 1234": ["firstViz", "secondViz"],
-      "zone12ce1e7d-51b5-40b7-bcb8-358cb84da400": ["thirdViz"],
+      "building kreuzberg 1234": "['firstViz','secondViz']",
+      "zone12ce1e7d-51b5-40b7-bcb8-358cb84da400": "['thirdViz']",
     };
     let dashboardAllWidgets = [
       { id: 1, visualization: { name: "firstViz" } },
@@ -91,7 +91,7 @@ describe("filterWidgets", () => {
       },
     ];
     let dashboardAllowedWidgets = {
-      controller12345: ["firstViz", "someNameViz"],
+      controller12345: "['firstViz','someNameViz']",
     };
     let dashboardAllWidgets = [
       { id: 1, visualization: { name: "someNameViz" } },
@@ -112,7 +112,7 @@ describe("filterWidgets", () => {
       },
     ];
     let dashboardAllowedWidgets = {
-      controller12345: ["firstViz", "someNameViz"],
+      controller12345: "['firstViz','someNameViz']",
     };
     let dashboardAllWidgets = [
       { id: 1, visualization: { name: "someNameViz" } },
@@ -127,5 +127,29 @@ describe("filterWidgets", () => {
 
     let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
     expect([{ id: 1, visualization: { name: "someNameViz" } }, { id: 3 }]).toStrictEqual(result);
+  });
+  test("support compount visualization names", () => {
+    let dashboardAllowedWidgets = {
+      controller1: "['group1,group2']",
+      controller2: "['group1']",
+      controller3: "['group2']",
+    };
+    let dashboardAllWidgets = [
+      { id: 1, visualization: { name: "group1;group2" } },
+      {
+        id: 2,
+        visualization: { name: "someOtherNameViz" },
+      },
+    ];
+
+    // test for "group1"
+    let dashboardParameters2 = [
+      {
+        name: "controller_param",
+        value: "controller2",
+      },
+    ];
+    let result2 = getAllowedWidgetsForCurrentParam(dashboardParameters2, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect([{ id: 1, visualization: { name: "group1;group2" } }]).toStrictEqual(result2);
   });
 });

--- a/client/app/pages/dashboards/hooks/utils.test.js
+++ b/client/app/pages/dashboards/hooks/utils.test.js
@@ -1,12 +1,9 @@
 import { getAllowedWidgetsForCurrentParam } from "@/pages/dashboards/hooks/utils";
 describe("filterWidgets", () => {
-  test("filter only for allowed widgets per main param value", () => {
+  test("filter only for allowed widgets per main parameter value", () => {
     let dashboardParameters = [
       {
         name: "controller_param",
-        title: "Controller param",
-        type: "text",
-        urlPrefix: "p_",
         value: "controller12345",
       },
     ];
@@ -26,13 +23,10 @@ describe("filterWidgets", () => {
       { id: 2, visualization: { name: "secondViz" } },
     ]).toStrictEqual(result);
   });
-  test("filters correctly in case of many params", () => {
+  test("filter correctly in case of many parameters", () => {
     let dashboardParameters = [
       {
         name: "controller_param",
-        title: "Controller param",
-        type: "text",
-        urlPrefix: "p_",
         value: "controller12345",
       },
       {
@@ -70,9 +64,6 @@ describe("filterWidgets", () => {
     let dashboardParameters = [
       {
         name: "controller_param",
-        title: "Controller param",
-        type: "text",
-        urlPrefix: "p_",
         value: "controller12345",
       },
     ];
@@ -99,9 +90,6 @@ describe("filterWidgets", () => {
     let dashboardParameters = [
       {
         name: "controller_param",
-        title: "Controller param",
-        type: "text",
-        urlPrefix: "p_",
         value: "controller12345",
       },
     ];

--- a/client/app/pages/dashboards/hooks/utils.test.js
+++ b/client/app/pages/dashboards/hooks/utils.test.js
@@ -1,0 +1,122 @@
+import { getAllowedWidgetsForCurrentParam } from "@/pages/dashboards/hooks/utils";
+describe("filterWidgets", () => {
+  test("filter only for allowed widgets per main param value", () => {
+    let dashboardParameters = [
+      {
+        name: "controller_param",
+        title: "Controller param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "controller12345",
+      },
+    ];
+    let dashboardAllowedWidgets = {
+      controller12345: ["firstViz", "secondViz"],
+      "4d678ac-cdbc-49c4-ba0f-c8800bce5e8c": ["thirdViz"],
+    };
+    let dashboardAllWidgets = [
+      { id: 1, visualization: { name: "firstViz" } },
+      { id: 2, visualization: { name: "secondViz" } },
+      { id: 3, visualization: { name: "thirdViz" } },
+    ];
+
+    let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect([
+      { id: 1, visualization: { name: "firstViz" } },
+      { id: 2, visualization: { name: "secondViz" } },
+    ]).toStrictEqual(result);
+  });
+  test("filters correctly in case of many params", () => {
+    let dashboardParameters = [
+      {
+        name: "controller_param",
+        title: "Controller param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "controller12345",
+      },
+      {
+        name: "building_address_param", // order of params is important in this test
+        title: "Building address param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "building kreuzberg 1234",
+      },
+      {
+        name: "zone_uuid_param",
+        title: "Zone UUID param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "zone12ce1e7d-51b5-40b7-bcb8-358cb84da400",
+      },
+    ];
+    let dashboardAllowedWidgets = {
+      "building kreuzberg 1234": ["firstViz", "secondViz"],
+      "zone12ce1e7d-51b5-40b7-bcb8-358cb84da400": ["thirdViz"],
+    };
+    let dashboardAllWidgets = [
+      { id: 1, visualization: { name: "firstViz" } },
+      { id: 2, visualization: { name: "secondViz" } },
+      { id: 3, visualization: { name: "thirdViz" } },
+    ];
+
+    let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect([
+      { id: 1, visualization: { name: "firstViz" } },
+      { id: 2, visualization: { name: "secondViz" } },
+    ]).toStrictEqual(result);
+  });
+  test("return all widgets if allowed_widgets is undefined", () => {
+    let dashboardParameters = [
+      {
+        name: "controller_param",
+        title: "Controller param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "controller12345",
+      },
+    ];
+    let dashboardAllowedWidgets = undefined;
+    let dashboardAllWidgets = [
+      {
+        id: 1,
+        visualization: { name: "firstViz" },
+      },
+      {
+        id: 2,
+        visualization: { name: "secondViz" },
+      },
+      {
+        id: 3,
+        visualization: { name: "thirdViz" },
+      },
+    ];
+
+    let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect(dashboardAllWidgets).toStrictEqual(result);
+  });
+  test("not found widget is just not returned", () => {
+    let dashboardParameters = [
+      {
+        name: "controller_param",
+        title: "Controller param",
+        type: "text",
+        urlPrefix: "p_",
+        value: "controller12345",
+      },
+    ];
+    let dashboardAllowedWidgets = {
+      controller12345: ["firstViz", "someNameViz"],
+    };
+    let dashboardAllWidgets = [
+      { id: 1, visualization: { name: "someNameViz" } },
+      {
+        id: 2,
+        visualization: { name: "someOtherNameViz" },
+      },
+    ];
+
+    let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect([{ id: 1, visualization: { name: "someNameViz" } }]).toStrictEqual(result);
+  });
+});

--- a/client/app/pages/dashboards/hooks/utils.test.js
+++ b/client/app/pages/dashboards/hooks/utils.test.js
@@ -23,6 +23,7 @@ describe("filterWidgets", () => {
       { id: 2, visualization: { name: "secondViz" } },
     ]).toStrictEqual(result);
   });
+
   test("filter correctly in case of many parameters", () => {
     let dashboardParameters = [
       {
@@ -31,16 +32,10 @@ describe("filterWidgets", () => {
       },
       {
         name: "building_address_param", // order of params is important in this test
-        title: "Building address param",
-        type: "text",
-        urlPrefix: "p_",
         value: "building kreuzberg 1234",
       },
       {
         name: "zone_uuid_param",
-        title: "Zone UUID param",
-        type: "text",
-        urlPrefix: "p_",
         value: "zone12ce1e7d-51b5-40b7-bcb8-358cb84da400",
       },
     ];
@@ -60,6 +55,7 @@ describe("filterWidgets", () => {
       { id: 2, visualization: { name: "secondViz" } },
     ]).toStrictEqual(result);
   });
+
   test("return all widgets if allowed_widgets is undefined", () => {
     let dashboardParameters = [
       {
@@ -86,6 +82,7 @@ describe("filterWidgets", () => {
     let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
     expect(dashboardAllWidgets).toStrictEqual(result);
   });
+
   test("not found widget is just not returned", () => {
     let dashboardParameters = [
       {

--- a/client/app/pages/dashboards/hooks/utils.test.js
+++ b/client/app/pages/dashboards/hooks/utils.test.js
@@ -104,4 +104,28 @@ describe("filterWidgets", () => {
     let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
     expect([{ id: 1, visualization: { name: "someNameViz" } }]).toStrictEqual(result);
   });
+  test("always show textboxes widgets", () => {
+    let dashboardParameters = [
+      {
+        name: "controller_param",
+        value: "controller12345",
+      },
+    ];
+    let dashboardAllowedWidgets = {
+      controller12345: ["firstViz", "someNameViz"],
+    };
+    let dashboardAllWidgets = [
+      { id: 1, visualization: { name: "someNameViz" } },
+      {
+        id: 2,
+        visualization: { name: "someOtherNameViz" },
+      },
+      {
+        id: 3, // textbox widget since it does not have a visualization
+      },
+    ];
+
+    let result = getAllowedWidgetsForCurrentParam(dashboardParameters, dashboardAllowedWidgets, dashboardAllWidgets);
+    expect([{ id: 1, visualization: { name: "someNameViz" } }, { id: 3 }]).toStrictEqual(result);
+  });
 });

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -136,9 +136,28 @@ function prepareDashboardWidgets(widgets) {
   return prepareWidgetsForDashboard(_.map(widgets, widget => new Widget(widget)));
 }
 
+function getAllowedWidgetsForCurrentParam(dashboard) {
+  try {
+    // filter the widgets by keeping only the ones we want
+    // get identifier of the current controller
+    const widgetQueryParams = dashboard.widgets[0].visualization.query.options.parameters;
+    const controllerParam = widgetQueryParams.filter(param => param.name === "controller_param")[0].value;
+
+    // get the allowed widgets for the current controller
+    const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
+    // filter the widgets to process
+    dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
+  } catch (error) {
+    console.error(error);
+  }
+
+  return dashboard.widgets;
+}
+
 function transformSingle(dashboard) {
   dashboard = new Dashboard(dashboard);
   if (dashboard.widgets) {
+    dashboard.widgets = getAllowedWidgetsForCurrentParam(dashboard);
     dashboard.widgets = prepareDashboardWidgets(dashboard.widgets);
   }
   dashboard.publicAccessEnabled = dashboard.public_url !== undefined;

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -139,7 +139,9 @@ function prepareDashboardWidgets(widgets) {
 function transformSingle(dashboard) {
   dashboard = new Dashboard(dashboard);
   if (dashboard.widgets) {
+    // save all widgets so that we can re-filter without refreshing the dashboard later
     dashboard.saved_all_widgets = prepareDashboardWidgets(dashboard.widgets);
+
     dashboard.widgets = prepareDashboardWidgets(dashboard.widgets);
   }
   dashboard.publicAccessEnabled = dashboard.public_url !== undefined;

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -139,6 +139,7 @@ function prepareDashboardWidgets(widgets) {
 function transformSingle(dashboard) {
   dashboard = new Dashboard(dashboard);
   if (dashboard.widgets) {
+    dashboard.saved_all_widgets = prepareDashboardWidgets(dashboard.widgets);
     dashboard.widgets = prepareDashboardWidgets(dashboard.widgets);
   }
   dashboard.publicAccessEnabled = dashboard.public_url !== undefined;

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -136,28 +136,9 @@ function prepareDashboardWidgets(widgets) {
   return prepareWidgetsForDashboard(_.map(widgets, widget => new Widget(widget)));
 }
 
-function getAllowedWidgetsForCurrentParam(dashboard) {
-  try {
-    // filter the widgets by keeping only the ones we want
-    // get identifier of the current controller
-    const widgetQueryParams = dashboard.widgets[0].visualization.query.options.parameters;
-    const controllerParam = widgetQueryParams.filter(param => param.name === "controller_param")[0].value;
-
-    // get the allowed widgets for the current controller
-    const allowedWidgetsIds = dashboard.allowed_widgets[controllerParam];
-    // filter the widgets to process
-    dashboard.widgets = dashboard.widgets.filter(widget => allowedWidgetsIds.includes(widget.id));
-  } catch (error) {
-    console.error(error);
-  }
-
-  return dashboard.widgets;
-}
-
 function transformSingle(dashboard) {
   dashboard = new Dashboard(dashboard);
   if (dashboard.widgets) {
-    dashboard.widgets = getAllowedWidgetsForCurrentParam(dashboard);
     dashboard.widgets = prepareDashboardWidgets(dashboard.widgets);
   }
   dashboard.publicAccessEnabled = dashboard.public_url !== undefined;

--- a/metr_docs/README.md
+++ b/metr_docs/README.md
@@ -201,7 +201,7 @@ Enabling Pre-commit check before commit.
 
 - make sure redis is running by executing command `redis-server` on terminal
 - make sure to copy .env-example tp `.env` and fill the values for for `REDASH_COOKIE_SECRET` and `REDASH_SECRET_KEY` and `DATABASE_URL`
-- create a local db for redash and run `./manage.py create_tables`
+- create a local db for redash and run `./manage.py database create_tables`
 - make sure that your `REDASH_DATABASE_URL` / `SQLALCHEMY_DATABASE_URI` is updated with the newly created db
 - start the scheduler and the worker with `./manage.py rq scheduler` and `./manage.py rq worker`
 - run the server from inside redash dir with the command `flask run --host=127.0.0.1 --port=5001`

--- a/metr_docs/README.md
+++ b/metr_docs/README.md
@@ -212,6 +212,7 @@ Enabling Pre-commit check before commit.
 
 - command to test backend is `pytest`
 - command to test frontend is `yarn test`
+- command to run one frontend test named "testName" is `yarn jest -t "testName"`
   checking your installed dependencies for any failing tests
 
 - for installing cypress on mac

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -194,19 +194,20 @@ class DashboardResource(BaseResource):
 
         self.record_event({"action": "view", "object_id": dashboard.id, "object_type": "dashboard"})
 
-        allowed_widgets=self.get_allowed_widgets_info()
+        allowed_widgets=self.get_allowed_widgets_info(dashboard_id)
         if allowed_widgets:
             response["allowed_widgets"]=allowed_widgets
         
         return response
 
-    def get_allowed_widgets_info(self):
-        query = models.Query.query.filter(models.Query.name=="allowed_widgets").first()
+    def get_allowed_widgets_info(self,dashboard_id):
+        query_name=f"allowed_widgets_{dashboard_id}"
+        query = models.Query.query.filter(models.Query.name==query_name).first()
         allowed_widgets={}
         if query:
             data = query.latest_query_data.data["rows"]
             for row in data:
-                allowed_widgets[row["controller_parameter"]]=row["allowed_widgets"] 
+                allowed_widgets[row["main_parameter"]]=row["allowed_widgets"] 
         return allowed_widgets
 
     @require_permission("edit_dashboard")

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -4,7 +4,6 @@ from funcy import partial, project
 from sqlalchemy.orm.exc import StaleDataError
 
 from redash import models
-from redash.authentication.org_resolving import current_org
 from redash.handlers.base import (
     BaseResource,
     filter_by_tags,
@@ -202,7 +201,7 @@ class DashboardResource(BaseResource):
         return response
 
     def get_allowed_widgets_info(self):
-        query = models.Query.query.filter(models.Query.name=="allowed_widgets",models.Query.org_id==current_org.id ).first()
+        query = models.Query.query.filter(models.Query.name=="allowed_widgets").first()
         allowed_widgets={}
         if query:
             data = query.latest_query_data.data["rows"]

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -136,14 +136,21 @@ class MyDashboardsResource(BaseResource):
 
 
 def get_allowed_widgets_info(dashboard_id):
+    """ This function adds allowed_widgets info to the data to return to frontend 
+    if we have a query named as follow f"allowed_widgets_{dashboard_id}". 
+    It returns an empty dictionary if the query does not exist """
+    # get the query having the allowed widgets information for the current dashboard
     query_name = f"allowed_widgets_{dashboard_id}"
     query = models.Query.query.filter(models.Query.name == query_name).first()
+    
+    # construct the allowed_widgets dictionary from the query data
     allowed_widgets = {}
     if query:
         data = query.latest_query_data.data["rows"]
         for row in data:
             if "main_parameter" in row.keys() and "allowed_widgets" in row.keys():
                 allowed_widgets[row["main_parameter"]] = row["allowed_widgets"]
+
     return allowed_widgets
 
 
@@ -206,6 +213,7 @@ class DashboardResource(BaseResource):
 
         self.record_event({"action": "view", "object_id": dashboard.id, "object_type": "dashboard"})
 
+        # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
         allowed_widgets = get_allowed_widgets_info(dashboard_id)
         if allowed_widgets:
             response["allowed_widgets"] = allowed_widgets

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -148,8 +148,8 @@ def get_allowed_widgets_info(dashboard_id):
     if query:
         data = query.latest_query_data.data["rows"]
         for row in data:
-            if "main_parameter" in row.keys() and "allowed_widgets" in row.keys():
-                allowed_widgets[row["main_parameter"]] = row["allowed_widgets"]
+            if "main_parameter" in row.keys() and "widgets" in row.keys():
+                allowed_widgets[row["main_parameter"]] = row["widgets"]
 
     return allowed_widgets
 

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -153,9 +153,22 @@ def get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name):
 
     return allowed_widgets
 
+def add_allowed_widgets_info(method):
+    def wrapper(self, dashboard_id):
+        result=method(self, dashboard_id)
+
+        # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
+        parameter_col_name="main_parameter"
+        widgets_col_name="widgets"
+        allowed_widgets = get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name)
+        if allowed_widgets:
+            result["allowed_widgets"] = allowed_widgets
+        return result
+    return wrapper
 
 class DashboardResource(BaseResource):
     @require_permission("list_dashboards")
+    @add_allowed_widgets_info
     def get(self, dashboard_id=None):
         """
         Retrieves a dashboard.
@@ -212,14 +225,6 @@ class DashboardResource(BaseResource):
         response["can_edit"] = can_modify(dashboard, self.current_user)
 
         self.record_event({"action": "view", "object_id": dashboard.id, "object_type": "dashboard"})
-
-        # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
-        parameter_col_name="main_parameter"
-        widgets_col_name="widgets"
-        allowed_widgets = get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name)
-        if allowed_widgets:
-            response["allowed_widgets"] = allowed_widgets
-
         return response
 
     @require_permission("edit_dashboard")

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -135,7 +135,7 @@ class MyDashboardsResource(BaseResource):
         return paginate(ordered_results, page, page_size, DashboardSerializer)
 
 
-def get_allowed_widgets_info(dashboard_id):
+def get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name):
     """ This function adds allowed_widgets info to the data to return to frontend 
     if we have a query named as follow f"allowed_widgets_{dashboard_id}". 
     It returns an empty dictionary if the query does not exist """
@@ -148,8 +148,8 @@ def get_allowed_widgets_info(dashboard_id):
     if query:
         data = query.latest_query_data.data["rows"]
         for row in data:
-            if "main_parameter" in row.keys() and "widgets" in row.keys():
-                allowed_widgets[row["main_parameter"]] = row["widgets"]
+            if parameter_col_name in row.keys() and widgets_col_name in row.keys():
+                allowed_widgets[row[parameter_col_name]] = row[widgets_col_name]
 
     return allowed_widgets
 
@@ -214,7 +214,9 @@ class DashboardResource(BaseResource):
         self.record_event({"action": "view", "object_id": dashboard.id, "object_type": "dashboard"})
 
         # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
-        allowed_widgets = get_allowed_widgets_info(dashboard_id)
+        parameter_col_name="main_parameter"
+        widgets_col_name="widgets"
+        allowed_widgets = get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name)
         if allowed_widgets:
             response["allowed_widgets"] = allowed_widgets
 

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -4,26 +4,40 @@ from redash.handlers.dashboards import get_allowed_widgets_info
 
 class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
     def test_return_allowed_widgets_if_the_query_exists(self):
+        dashboard_id = 1
+
+        # create query holding allowed widgets info
         data = {
             "rows": [{"main_parameter": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
             "columns": [{"name": "main_parameter"}, {"name": "allowed_widgets"}],
         }
         query_data_result = self.factory.create_query_result(data=data)
-        dashboard_id = 1
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
+
+        # call function to test
         allowed_widgets = get_allowed_widgets_info(dashboard_id)
+
+        # assertions
         assert {"controller1234": ["firstQueryViz", "secondQueryViz"]} == allowed_widgets
 
     def test_allowed_widgets_is_empty_if_wrong_query_row_keys(self):
+        dashboard_id = 1
+
+        # create query holding allowed widgets info
         data = {
             "rows": [{"main_param": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
             "columns": [{"name": "main_param"}, {"name": "allowed_widgets"}],
         }
         query_data_result = self.factory.create_query_result(data=data)
-        dashboard_id = 1
+
+        # call function to test
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
+
+        # assertions
         assert get_allowed_widgets_info(dashboard_id) == {}
 
     def test_allowed_widgets_is_empty_if_the_query_doesnt_exists(self):
         dashboard_id = 1
+
+        # call function to test and assert its result
         assert get_allowed_widgets_info(dashboard_id) == {}

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -5,28 +5,32 @@ from redash.handlers.dashboards import get_allowed_widgets_info
 class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
     def test_return_allowed_widgets_if_the_query_exists(self):
         dashboard_id = 1
+        parameter_col_name="main_parameter"
+        widgets_col_name="widgets"
 
         # create query holding allowed widgets info
         data = {
-            "rows": [{"main_parameter": "controller1234", "widgets": ["firstQueryViz", "secondQueryViz"]}],
-            "columns": [{"name": "main_parameter"}, {"name": "widgets"}],
+            "rows": [{parameter_col_name: "controller1234", widgets_col_name: ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": parameter_col_name}, {"name": widgets_col_name}],
         }
         query_data_result = self.factory.create_query_result(data=data)
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
 
         # call function to test
-        allowed_widgets = get_allowed_widgets_info(dashboard_id)
+        allowed_widgets = get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name)
 
         # assertions
         assert {"controller1234": ["firstQueryViz", "secondQueryViz"]} == allowed_widgets
 
     def test_allowed_widgets_is_empty_if_wrong_query_row_keys(self):
         dashboard_id = 1
+        parameter_col_name="main_param"
+        widgets_col_name="widgets"
 
         # create query holding allowed widgets info
         data = {
-            "rows": [{"main_param": "controller1234", "widgets": ["firstQueryViz", "secondQueryViz"]}],
-            "columns": [{"name": "main_param"}, {"name": "widgets"}],
+            "rows": [{parameter_col_name: "controller1234", widgets_col_name: ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": parameter_col_name}, {"name":widgets_col_name}],
         }
         query_data_result = self.factory.create_query_result(data=data)
 
@@ -34,10 +38,12 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
 
         # assertions
-        assert get_allowed_widgets_info(dashboard_id) == {}
+        assert get_allowed_widgets_info(dashboard_id,"main_parameter",widgets_col_name) == {}
 
     def test_allowed_widgets_is_empty_if_the_query_doesnt_exists(self):
         dashboard_id = 1
+        parameter_col_name="main_parameter"
+        widgets_col_name="widgets"
 
         # call function to test and assert its result
-        assert get_allowed_widgets_info(dashboard_id) == {}
+        assert get_allowed_widgets_info(dashboard_id,parameter_col_name,widgets_col_name) == {}

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -1,7 +1,30 @@
 from tests import BaseTestCase
-from redash.handlers.dashboards import get_allowed_widgets_info
+from redash.handlers.dashboards import add_allowed_widgets_info, get_allowed_widgets_info
 
+class TestAddAllowedWidgetsInfo(BaseTestCase):
+    def test_add_allowed_widgets_info_works_correctly(self):
+        parameter_col_name="main_parameter"
+        widgets_col_name="widgets"
+        dashboard_id=1
+        data = {
+            "rows": [{parameter_col_name: "controller1234", widgets_col_name: ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": parameter_col_name}, {"name": widgets_col_name}],
+        }
 
+        query_data_result = self.factory.create_query_result(data=data)
+        self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
+
+        class ClassToTest():
+            @add_allowed_widgets_info
+            def test_method(self,dashboard_id):
+                return {"info":"info detail"}
+            
+        instance=ClassToTest()
+        result=instance.test_method(1)
+        
+        assert 'allowed_widgets' in result
+        assert result["allowed_widgets"]=={'controller1234': ['firstQueryViz', 'secondQueryViz']}
+        
 class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
     def test_return_allowed_widgets_if_the_query_exists(self):
         dashboard_id = 1

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -1,0 +1,29 @@
+from tests import BaseTestCase
+from redash.handlers.dashboards import get_allowed_widgets_info
+
+
+class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
+    def test_return_allowed_widgets_if_the_query_exists(self):
+        data = {
+            "rows": [{"main_parameter": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": "main_parameter"}, {"name": "allowed_widgets"}],
+        }
+        query_data_result = self.factory.create_query_result(data=data)
+        dashboard_id = 1
+        self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
+        allowed_widgets = get_allowed_widgets_info(dashboard_id)
+        assert {"controller1234": ["firstQueryViz", "secondQueryViz"]} == allowed_widgets
+
+    def test_allowed_widgets_is_empty_if_wrong_query_row_keys(self):
+        data = {
+            "rows": [{"main_param": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": "main_param"}, {"name": "allowed_widgets"}],
+        }
+        query_data_result = self.factory.create_query_result(data=data)
+        dashboard_id = 1
+        self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
+        assert get_allowed_widgets_info(dashboard_id) == {}
+
+    def test_allowed_widgets_is_empty_if_the_query_doesnt_exists(self):
+        dashboard_id = 1
+        assert get_allowed_widgets_info(dashboard_id) == {}

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -8,8 +8,8 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
 
         # create query holding allowed widgets info
         data = {
-            "rows": [{"main_parameter": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
-            "columns": [{"name": "main_parameter"}, {"name": "allowed_widgets"}],
+            "rows": [{"main_parameter": "controller1234", "widgets": ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": "main_parameter"}, {"name": "widgets"}],
         }
         query_data_result = self.factory.create_query_result(data=data)
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
@@ -25,8 +25,8 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
 
         # create query holding allowed widgets info
         data = {
-            "rows": [{"main_param": "controller1234", "allowed_widgets": ["firstQueryViz", "secondQueryViz"]}],
-            "columns": [{"name": "main_param"}, {"name": "allowed_widgets"}],
+            "rows": [{"main_param": "controller1234", "widgets": ["firstQueryViz", "secondQueryViz"]}],
+            "columns": [{"name": "main_param"}, {"name": "widgets"}],
         }
         query_data_result = self.factory.create_query_result(data=data)
 


### PR DESCRIPTION
## What type of PR is this? 

This is an extension of an existing feature . The existing feature shows all the dashboard's widgets in the dashboard page, no matter what the dashboard parameters values are. 

In our extension (the code in this PR) we add the possibility to only show the allowed widgets according to a parameter value.

You can see this happening on staging [in this video ](https://drive.google.com/file/d/17ppzCbC1rztZ6bR25BrldsddPTbkqTdh/view?usp=sharing)

![hideandsee](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDVmMTh4cmxxNHhsNzN3NjhoeDE0MHJmeGhmMmM2b29reXZrMGVpOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MzZWQV6VGPMvTkaxFc/giphy.gif)

## Pre-Description

- This has been developed : 
Assuming that the dashboard parameters that we use -in our case- never share common values. 


## Description

After we include this code in our image of redash, we will be able to only show the widgets that we want for the dashboards that we  wish to customise.

The introduced code is a transition before the final state where we will be getting the list of allowed_widgets from our product re****_mo**** directly.

But, in order to make it work for now, we need to have certain things set: 

1- The **allowed_widgets_dashboardID** query 

* The alllowed_widgets query needs to have its name in the format `allowed_widgets_{dashboardID} `
* If a dashboard has no related alllowed_widgets query, it will simply show all the widgets without filtering.
*The query should have the following columns : `main_parameter` and `widgets`, where `main_parameter` will include the parameter values , for each parameter value that we want to customise, we specify the list of widgets we want to show, a widget is identified by its visualisation name

example : 

```sql 

select "collector123" as "main_parameter",  "['heat1', 'water2']" as "widgets"
union select "zone456" as "main_parameter",  "['heat1', 'heat2']" as "widgets"

```
2- The visualisations names 

* For every widget that we want to show when we want, we should add a name to its visualisation (so far only one ... in the futur many)

example : `'heat1'` as visualization name

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually , check video mentioned above

## What is next?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnp4Y3YxNGV4a25kYzFsMHowMTZ3NjkxdGV6bTFubDlrdDZnNWR0dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9CrVjsT4y6Jxu/giphy.gif)

- using the widgets tags instead of the visualisation names (but will they really be better than the visualisation names)
- build the allowed_widgets query directly from our product re****_mo****
- discuss the positioning of the widgets if needed


## Related Tickets & Documents

Closes https://github.com/orgs/metr-systems/projects/18/views/1?pane=issue&itemId=74429589
Closes https://github.com/orgs/metr-systems/projects/18/views/1?pane=issue&itemId=74429568
Closes https://github.com/orgs/metr-systems/projects/18/views/1?pane=issue&itemId=74429622
