### PR TITLE
Fixing refresh for allowed widgets

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -151,7 +151,7 @@ function useDashboard(dashboardData) {
         setFilters(updatedFilters);
       });
     },
-    [loadWidget]
+    [globalParameters, loadWidget]
   );
 
   const refreshDashboard = useCallback(


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description:
Clicking on the button "refresh" was messing with our hidden widgets and makes them appear again while they should not

## Interesting notes about the code:

In the following three notes I introduce briefly the main variables/function in the code:

- `updatedParameters` holds values of the parameters after we change the value.

- `globalParameters` holds the initial values when we first open the dashboard, and i believe that it should be updated with the new values when they change, but this is not happening in the code.

- `dashboard.getParametersDefs()`: will get the current parameters from the url, but it does more, `globalParameters` are actually initialised with the value that `dashboard.getParametersDefs()` [returns in the beginning and uses useMemo to memoize it.](https://github.com/getredash/redash/blob/b922730482c18bf4ca52bfb3c4a764e73814dbdb/client/app/pages/dashboards/hooks/useDashboard.js#L43)

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWl2aWV1MWJ0NXU5OWdxN3Q3bHlxbHFtc3JkN3lldHJ1Mmg5aWxmdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MP7zZ4DeRqmgQiRpf4/giphy.gif)

   - [A created DashboardComponent uses the custom hook useDashboard to manage its configuration,](https://github.com/getredash/redash/blob/b922730482c18bf4ca52bfb3c4a764e73814dbdb/client/app/pages/dashboards/DashboardPage.jsx#L74) this hooks will be used whenever we need to load the dashboard, refresh it, edit it or publish it, add widgets or remove widgets from it and much more. 
   - When we open a new page the dashboard loads twice because we would have two useEffect hooks calling it, check [first one](https://github.com/getredash/redash/blob/673ba769c7372d015107c466c65790c2073cf0e6/client/app/pages/dashboards/hooks/useDashboard.js#L207) , [second one](https://github.com/getredash/redash/blob/673ba769c7372d015107c466c65790c2073cf0e6/client/app/pages/dashboards/hooks/useDashboard.js#L217)
- In these useEffect hooks `loadDashboard` Is called with its default parameters `(forceRefresh = false, updatedParameters = [])`
- —> This is why earlier in the code I was checking if we have no `updatedParameters` then I use `globalParameters` 
- But I ended up discovering that `globalParameters` does not get updated with latest values selected, let me walk you through the process
- When you change a value of a parameter, `refreshDashboard` is triggered to refresh the widgets and it gets passes the `updatedParameters` that it calls `loadDashboard` and force the refresh
- `loadDashboard` will look for the affected widgets (the ones that use this parameter in their query) and force re-load them.
- But `globalParameters` does not get updated in the process, this is why the code was failing but here the problem does not appear since we have updatedParameters.
- But when clicking on the refresh button, `refreshDashboard` is triggered without `updatedParameters` and aims to update them all.
- The issue is we were using `globalParameters` when we have no `updatedParameters` and this what made our function `getAllowedWidgetsForCurrentParam` fail by using a deprecated parameter.
- In order to resolve it, we get the current parameter directly by the url using formattedParametersFromUrl
- We could have used `dashboard.getParametersDefs()`, but this one would go from dashboard to widget to query and aims to update the parameters mapping …thing that will be also done when re-loading the widgets… 
- so in order to keep the process as light as possible and to not impact how things work, I chose in the beginning a much simpler solution `formattedParametersFromUrl`

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2ZidWNpbmVjc21vNXc4MG45YzE4b2p2NmY4bGt0NXFlaGZvczBxMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/85RgbIVvsEjlVmC3cJ/giphy.gif)

- And after I wrote all this I noticed that I could make `globalParameters` refresh every time `dashboardData` changes and I believe that it is a much better solution 

- `globalParameters` is already being refreshed because you can find in its definition that it gets refreshed everytime dashboard changes and dashboard is initialized with `dashboardData` but then it get update using `setDashboard` [everytime in useEffect](https://github.com/metr-systems/redash/blob/67f36ea83c66217c70efa720899453e9229af971/client/app/pages/dashboards/hooks/useDashboard.js#L218)

- It is just that we need to make `loadDashboard` use the latest value of `globalParameters` and this by adding it as a dependency as it is done here in this PR

## How is this tested?

- [x] Manually

you can also check it on staging 