### PR TITLE
Auto refresh when open dashboard

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -216,7 +216,10 @@ function useDashboard(dashboardData) {
 
   useEffect(() => {
     setDashboard(dashboardData);
-    loadDashboard();
+    if (!refreshing) {
+      setRefreshing(true);
+      loadDashboard(true, []).finally(() => setRefreshing(false));
+    }
   }, [dashboardData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -3,6 +3,7 @@ import { isEmpty, includes, compact, map, has, pick, keys, extend, every, get } 
 import notification from "@/services/notification";
 import location from "@/services/location";
 import url from "@/services/url";
+import { clientConfig } from "@/services/auth";
 import { Dashboard, collectDashboardFilters } from "@/services/dashboard";
 import { currentUser } from "@/services/auth";
 import recordEvent from "@/services/recordEvent";
@@ -216,9 +217,13 @@ function useDashboard(dashboardData) {
 
   useEffect(() => {
     setDashboard(dashboardData);
-    if (!refreshing) {
-      setRefreshing(true);
-      loadDashboard(true, []).finally(() => setRefreshing(false));
+    if (clientConfig.enableDashboardAutoRefresh) {
+      if (!refreshing) {
+        setRefreshing(true);
+        loadDashboard(true, []).finally(() => setRefreshing(false));
+      }
+    } else {
+      loadDashboard();
     }
   }, [dashboardData]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
@@ -46,6 +46,14 @@ export default function FeatureFlagsSettings(props) {
                 Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
               </Checkbox>
             </Row>
+            <Row>
+              <Checkbox
+                name="enable_auto_refresh_when_opening_dashboard"
+                checked={values.enable_auto_refresh_when_opening_dashboard}
+                onChange={e => onChange({ enable_auto_refresh_when_opening_dashboard: e.target.checked })}>
+                Enable auto-refresh when opening a dashboard page
+              </Checkbox>
+            </Row>
           </>
         )}
       </Form.Item>

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -266,6 +266,7 @@ def client_config():
         "showPermissionsControl": current_org.get_setting("feature_show_permissions_control"),
         "hidePlotlyModeBar": current_org.get_setting("hide_plotly_mode_bar"),
         "disablePublicUrls": current_org.get_setting("disable_public_urls"),
+        "enableDashboardAutoRefresh": current_org.get_setting("enable_auto_refresh_when_opening_dashboard"),
         "allowCustomJSVisualizations": settings.FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS,
         "autoPublishNamedQueries": settings.FEATURE_AUTO_PUBLISH_NAMED_QUERIES,
         "extendedAlertOptions": settings.FEATURE_EXTENDED_ALERT_OPTIONS,

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -44,6 +44,8 @@ SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES = parse_boolean(
 HIDE_PLOTLY_MODE_BAR = parse_boolean(os.environ.get("HIDE_PLOTLY_MODE_BAR", "false"))
 DISABLE_PUBLIC_URLS = parse_boolean(os.environ.get("REDASH_DISABLE_PUBLIC_URLS", "false"))
 
+ENABLE_AUTO_REFRESH_WHEN_OPENING_DASHBOARD=parse_boolean(os.environ.get("ENABLE_AUTO_REFRESH_WHEN_OPENING_DASHBOARD", "false"))
+
 settings = {
     "auth_password_login_enabled": PASSWORD_LOGIN_ENABLED,
     "auth_saml_enabled": SAML_LOGIN_ENABLED,
@@ -70,4 +72,5 @@ settings = {
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,
     "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,
     "disable_public_urls": DISABLE_PUBLIC_URLS,
+    "enable_auto_refresh_when_opening_dashboard":ENABLE_AUTO_REFRESH_WHEN_OPENING_DASHBOARD
 }


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
In this PR we introduce the feature of optionally automatically refresh the dashboard widget query results once we open the dashboard page 

- We added a feature flag that will allow us to enable the auto-refresh separately for every organisation as you can check it [on staging. ](https://dashboard.staging.metr.systems/staging/settings/general)

<img width="966" alt="Screenshot 2024-10-30 at 12 03 23" src="https://github.com/user-attachments/assets/68247809-eacc-40a1-8fce-d56405591697">

- This feature flag is not ticked by default (false by default) , but once enabled ... it will refresh the dashboard widgets queries every-time it is accessed.

- FYI I noticed that for it to be activated in the beginning you need to reload the page (just for you who is activating it and not another person opening a link...also not you opening a link...just when switching pages just after updating it) so that the frontend gets the new configuration from the backend but this seems okay for me, i guess it is the situation with the other feature flags too.

## How is this tested?
- [x] Manually

You can check it on staging it is available

## Related Tickets & Documents
Closes https://github.com/metr-systems/backlog/issues/3601

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcG5mZDNyZ2gzOTllc3lqNXZxemdpMDZuemJzcjYzdmE2Z2NnNHN6MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MziKDo6gO7x8A/giphy.gif)
