### PR TITLE
only apply layouts order for dashboard for which we have a customized…

### DIFF
--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -179,8 +179,8 @@ class DashboardGrid extends React.Component {
     // fixes test dashboard_spec['shows widgets with full width']
     // TODO: open react-grid-layout issue
     if (layouts[MULTI]) {
-      if (!this.props.isEditing) {
-      newLayouts = this.applyLayoutsOrder(layouts);
+      if (!this.props.isEditing && this.props.dashboard.allowed_widgets) {
+        newLayouts = this.applyLayoutsOrder(layouts);
       }
       this.setState({ layouts: newLayouts });
     }


### PR DESCRIPTION
Follow-up to the [PR about fixing widgets positioning](https://github.com/metr-systems/redash/pull/9), aims to only apply the widgets re-ordering in the cases the fix was supposed to correct (i.e widgets disappearing and appearing i.e. when we have allowed_widgets) 

I will merge this PR right away because we need to deploy it as fix, it is already deployed on staging, I created the PR to explain the "why" of it. 