### PR TITLE
Only get the next state if there's a value

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -956,6 +956,7 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
 
     def evaluate(self):
         data = self.query_rel.latest_query_data.data
+        new_state = self.UNKNOWN_STATE
 
         if data["rows"] and self.options["column"] in data["rows"][0]:
             op = OPERATORS.get(self.options["op"], lambda v, t: False)
@@ -963,9 +964,8 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
             value = data["rows"][0][self.options["column"]]
             threshold = self.options["value"]
 
-            new_state = next_state(op, value, threshold)
-        else:
-            new_state = self.UNKNOWN_STATE
+            if value is not None:
+                new_state = next_state(op, value, threshold)
 
         return new_state
 

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -69,6 +69,10 @@ class TestAlertEvaluate(BaseTestCase):
         alert = self.create_alert(results)
         self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
 
+    def test_evaluate_return_unknown_when_value_is_none(self):
+        alert = self.create_alert(get_results(None))
+        self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
+
 
 class TestNextState(TestCase):
     def test_numeric_value(self):


### PR DESCRIPTION
We've received some Sentry errors because of this.

For some reason, sometimes the value is None, which breaks the code. In these cases, I'm also returning `UNKNOWN_STATE`, which does nothing.