### PR TITLE
Put invite and reset emails to their old state

### DIFF
--- a/redash/authentication/account.py
+++ b/redash/authentication/account.py
@@ -55,7 +55,7 @@ def send_invite_email(inviter, invited, invite_url, org):
     context = dict(inviter=inviter, invited=invited, org=org, invite_url=invite_url)
     html_content = render_template("emails/invite.html", **context)
     text_content = render_template("emails/invite.txt", **context)
-    subject = _("{} invited you to join Redash").format(inviter.name)
+    subject = "Erhalten Sie Zugriff auf Ihr metr-Dashboard"
 
     send_mail.delay([invited.email], subject, html_content, text_content)
 

--- a/redash/locales/messages.pot
+++ b/redash/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-12-10 13:06+0100\n"
+"POT-Creation-Date: 2024-12-11 16:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,10 +27,6 @@ msgstr ""
 
 #: redash/authentication/account.py:49
 msgid "{}, please verify your email address"
-msgstr ""
-
-#: redash/authentication/account.py:58
-msgid "{} invited you to join Redash"
 msgstr ""
 
 #: redash/authentication/account.py:68
@@ -377,47 +373,9 @@ msgstr ""
 msgid "Exception"
 msgstr ""
 
-#: redash/templates/emails/invite.html:5 redash/templates/emails/reset.html:5
 #: redash/templates/emails/reset_disabled.html:5
 #: redash/templates/emails/verify.html:5
 msgid "Hi"
-msgstr ""
-
-#: redash/templates/emails/invite.html:8
-msgid "invited you to join the Redash account of"
-msgstr ""
-
-#: redash/templates/emails/invite.html:10
-msgid "Setup Account"
-msgstr ""
-
-#: redash/templates/emails/invite.html:12
-#: redash/templates/emails/verify.html:12
-msgid "You may copy/paste this link into your browser:"
-msgstr ""
-
-#: redash/templates/emails/invite.html:15
-msgid "Your sign-in email is:"
-msgstr ""
-
-#: redash/templates/emails/invite.html:16
-msgid "Your Redash account is:"
-msgstr ""
-
-#: redash/templates/emails/reset.html:7
-msgid ""
-"You told us you forgot your password. If you really did, click here to "
-"choose a new one:"
-msgstr ""
-
-#: redash/templates/emails/reset.html:11
-msgid "Need the raw link?"
-msgstr ""
-
-#: redash/templates/emails/reset.html:14
-msgid ""
-"If you didn't mean to reset your password, then you can just ignore this "
-"email; your password will not change."
 msgstr ""
 
 #: redash/templates/emails/reset_disabled.html:7
@@ -437,6 +395,10 @@ msgstr ""
 
 #: redash/templates/emails/verify.html:10
 msgid "Verify Address"
+msgstr ""
+
+#: redash/templates/emails/verify.html:12
+msgid "You may copy/paste this link into your browser:"
 msgstr ""
 
 #: redash/utils/__init__.py:105

--- a/redash/templates/emails/invite.html
+++ b/redash/templates/emails/invite.html
@@ -27,11 +27,4 @@
     Freundliche Grüße<br>
     Ihr Team von metr
 </p>
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <br>
-    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    <br>
-    Kann man auf diese Mail antworten? <br>
-    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
-</p>
 {% endblock %}

--- a/redash/templates/emails/invite.html
+++ b/redash/templates/emails/invite.html
@@ -2,18 +2,36 @@
 
 {% block content %}
 
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">{{_('Hi')}} {{ invited.name }},</p>
-<h2 class="intercom-align-left" style="color: #282F33; font-size: 18px; font-weight: bold; margin-bottom: 7px; margin-top: 30px; text-align: left !important" align="left">
-    {{ inviter.name }} (<a href="mailto:{{ inviter.email }}" target="_blank" style="border: none; color: #1251BA; outline: none !important">{{ inviter.email }}</a>)
-   {{_('invited you to join the Redash account of')}} {{ org.name }}.
-</h2>
-<table class="intercom-container intercom-align-center" align="center" style="border-collapse: collapse; border-spacing: 0; margin: 17px auto; table-layout: fixed; text-align: center !important"><tr><td style="background: #0071b2; border: 1px none #dadada; border-radius: 3px; font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; padding: 12px 35px; text-align: left; vertical-align: top" align="left" bgcolor="#0071b2" valign="top"><a class="intercom-h2b-button" target="_blank" href="{{ invite_url }}" style="background: #0071b2; border: none; border-radius: 3px; color: white; display: inline-block; font-size: 14px; font-weight: bold; outline: none !important; text-decoration: none">{{_('Setup Account')}}</a></td></tr></table>
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">Hallo {{ invited.name }},</p>
+<p class="intercom-align-left" style="color: #282F33; font-size: 18px; margin-bottom: 7px; margin-top: 30px; text-align: left !important" align="left">
+    Sie wurden von  {{ inviter.name }} (<a href="mailto:{{ inviter.email }}" target="_blank" style="border: none; color: #1251BA; outline: none !important">{{ inviter.email }}</a>)
+    zu Ihrem metr-Dashboard eingeladen. Klicken Sie auf den Button, um Ihr Konto zu vervollständigen und Zugriff auf Dashboard zu erhalten:
+</p>
+<table class="intercom-container intercom-align-center" align="center" style="border-collapse: collapse; border-spacing: 0; margin: 17px auto; table-layout: fixed; text-align: center !important">
+    <tr>
+        <td style="background: #0071b2; border: 1px none #dadada; border-radius: 3px; font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; padding: 12px 35px; text-align: left; vertical-align: top" align="left" bgcolor="#0071b2" valign="top">
+            <a class="intercom-h2b-button" target="_blank" href="{{ invite_url }}" style="background: #0071b2; border: none; border-radius: 3px; color: white; display: inline-block; font-size: 14px; font-weight: bold; outline: none !important; text-decoration: none">
+                Konto vervollständigen
+            </a>
+        </td>
+    </tr>
+</table>
 <p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <small> {{_('You may copy/paste this link into your browser:')}} {{ invite_url }}</small>
+    Der Button funktioniert nicht? Dann kopieren Sie bitte diesen Link in Ihren Browser: {{ invite_url }}
 </p>
 <p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    {{_('Your sign-in email is:')}} {{ invited.email }}<br>
-    {{_('Your Redash account is:')}} <a href="{{ url_for('redash.index', org_slug=org.slug, _external=True) }}" target="_blank" style="border: none; color: #1251BA; outline: none !important">{{ url_for('redash.index', org_slug=org.slug, _external=True) }}</a>
+    Ihr Benutzername / Ihre E-Mail-Adresse: {{ invited.email }}<br>
+    Der Zugangslink zu Ihrem metr-Dashboard:  <a href="{{ url_for('redash.index', org_slug=org.slug, _external=True) }}" target="_blank" style="border: none; color: #1251BA; outline: none !important">{{ url_for('redash.index', org_slug=org.slug, _external=True) }}</a>
 </p>
-
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
+    Freundliche Grüße<br>
+    Ihr Team von metr
+</p>
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
+    <br>
+    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    <br>
+    Kann man auf diese Mail antworten? <br>
+    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
+</p>
 {% endblock %}

--- a/redash/templates/emails/invite.txt
+++ b/redash/templates/emails/invite.txt
@@ -1,10 +1,10 @@
-{{_('Hi')}} {{ invited.name }},
+Hallo {{ invited.name }},
 
-{{ inviter.name }} ({{inviter.email}}) {{_('invited you to join the Redash account of')}} {{org.name}}.
-
-{{_('Use the following link to setup your account:')}}
+Sie wurden von {{ inviter.name }} ({{inviter.email}}) zu Ihrem metr-Dashboard eingeladen. 
+zu Ihrem metr-Dashboard eingeladen. Klicken Sie auf den Link, um Ihr Konto zu vervollständigen und Zugriff auf Dashboard zu erhalten:
 
 {{ invite_url }}
 
-{{_('Your sign-in email:')}} {{invited.email}}
-{{_('Your Redash account:')}} {{ url_for('redash.index', org_slug=org.slug, _external=True) }}
+Ihr Benutzername / Ihre E-Mail-Adresse: {{ invited.name }} / {{invited.email}}
+Der Zugangslink zu Ihrem metr-Dashboard: {{ url_for('redash.index', org_slug=org.slug, _external=True) }}
+

--- a/redash/templates/emails/layout.html
+++ b/redash/templates/emails/layout.html
@@ -544,9 +544,9 @@ img.intercom-interblocks-article-author-avatar-image {
 
   <table width="100%" class="header" style="border-collapse: separate; border-spacing: 0; table-layout: fixed">
     <tr>
-      <td class="logo" style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; padding: 0; text-align: left" align="left">
+      <td class="logo" style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; padding: 0; text-align: right" align="right">
 
-          <img src="https://redash.io/assets/images/logo.png" width="165" height="86" class="featured" style="padding: 15px 0 30px; text-align: left">
+          <img src="https://dashboard-content.obs.eu-de.otc.t-systems.com/metr_logo_website.png" width="165" height="86" class="featured" style="padding: 15px 0 30px; text-align: right">
 
       </td>
     </tr>

--- a/redash/templates/emails/reset.html
+++ b/redash/templates/emails/reset.html
@@ -2,16 +2,34 @@
 
 {% block content %}
 
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">{{_('Hi')}} {{ user.name }},</p>
-<h2 class="intercom-align-left" style="color: #282F33; font-size: 18px; font-weight: bold; margin-bottom: 7px; margin-top: 30px; text-align: left !important" align="left">
-    {{ _("You told us you forgot your password. If you really did, click here to choose a new one:") }}
-</h2>
-<table class="intercom-container intercom-align-center" align="center" style="border-collapse: collapse; border-spacing: 0; margin: 17px auto; table-layout: fixed; text-align: center !important"><tr><td style="background: #0071b2; border: 1px none #dadada; border-radius: 3px; font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; padding: 12px 35px; text-align: left; vertical-align: top" align="left" bgcolor="#0071b2" valign="top"><a class="intercom-h2b-button" target="_blank" href="{{ reset_link }}" style="background: #0071b2; border: none; border-radius: 3px; color: white; display: inline-block; font-size: 14px; font-weight: bold; outline: none !important; text-decoration: none">{{ ("Choose a new password") }}</a></td></tr></table>
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">Hallo {{ user.name }},</p>
+<p class="intercom-align-left" style="color: #282F33; font-size: 18px; margin-bottom: 7px; margin-top: 30px; text-align: left !important" align="left">
+    Sie möchten Ihr Passwort zurücksetzen? Klicken Sie dazu einfach auf diesen Button:
+</p>
+<table class="intercom-container intercom-align-center" align="center" style="border-collapse: collapse; border-spacing: 0; margin: 17px auto; table-layout: fixed; text-align: center !important">
+    <tr>
+        <td style="background: #0071b2; border: 1px none #dadada; border-radius: 3px; font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; padding: 12px 35px; text-align: left; vertical-align: top" align="left" bgcolor="#0071b2" valign="top">
+            <a class="intercom-h2b-button" target="_blank" href="{{ reset_link }}" style="background: #0071b2; border: none; border-radius: 3px; color: white; display: inline-block; font-size: 14px; font-weight: bold; outline: none !important; text-decoration: none">
+                Passwort zurücksetzen
+            </a>
+        </td>
+    </tr>
+</table>
 <p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <small>{{ _("Need the raw link?") }} {{ reset_link }}</small>
+    Der Button funktioniert nicht? Dann kopieren Sie bitte diesen Link in Ihren Browser:  {{ reset_link }}
 </p>
 <p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    {{ _("If you didn't mean to reset your password, then you can just ignore this email; your password will not change.") }}
+    Falls Sie Ihr Passwort nicht zurücksetzen möchten, dann ignorieren Sie diese E-Mail ganz einfach. Ihr bisheriges Passwort bleibt bestehen. 
 </p>
-
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
+    Freundliche Grüße<br>
+    Ihr Team von metr
+</p>
+<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
+    <br>
+    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    <br>
+    Kann man auf diese Mail antworten? <br>
+    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
+</p>
 {% endblock %}

--- a/redash/templates/emails/reset.html
+++ b/redash/templates/emails/reset.html
@@ -25,11 +25,4 @@
     Freundliche Grüße<br>
     Ihr Team von metr
 </p>
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <br>
-    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    <br>
-    Kann man auf diese Mail antworten? <br>
-    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
-</p>
 {% endblock %}

--- a/redash/templates/emails/reset.txt
+++ b/redash/templates/emails/reset.txt
@@ -1,7 +1,7 @@
-{{_('Hi')}} {{ user.name }},
+Hallo {{ user.name }},
 
-{{_('You told us you forgot your password. If you really did, click here to choose a new one:')}}
+Sie möchten Ihr Passwort zurücksetzen? Klicken Sie dazu einfach auf diesen Link:
 
 {{ reset_link }}
 
-{{ _("If you didn't mean to reset your password, then you can just ignore this email; your password will not change.") }}
+Falls Sie Ihr Passwort nicht zurücksetzen möchten, dann ignorieren Sie diese E-Mail ganz einfach. Ihr bisheriges Passwort bleibt bestehen. 

--- a/redash/translations/de/LC_MESSAGES/messages.po
+++ b/redash/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Redash 10.0.0\n"
 "Report-Msgid-Bugs-To: engineering@metr.systems\n"
-"POT-Creation-Date: 2024-12-10 13:06+0100\n"
+"POT-Creation-Date: 2024-12-11 16:26+0100\n"
 "PO-Revision-Date: 2024-12-04 15:21+0100\n"
 "Last-Translator: metr Building Management Systems team "
 "<engineering@metr.systems>\n"
@@ -32,10 +32,6 @@ msgstr ""
 #: redash/authentication/account.py:49
 msgid "{}, please verify your email address"
 msgstr "{}, bitte bestätigen Sie Ihre E-Mail-Adresse"
-
-#: redash/authentication/account.py:58
-msgid "{} invited you to join Redash"
-msgstr "{} hat Sie eingeladen, Redash beizutreten"
 
 #: redash/authentication/account.py:68
 msgid "Reset your password"
@@ -411,52 +407,10 @@ msgstr "weitere Fehler seit dem letzten Bericht"
 msgid "Exception"
 msgstr "Ausnahme"
 
-#: redash/templates/emails/invite.html:5 redash/templates/emails/reset.html:5
 #: redash/templates/emails/reset_disabled.html:5
 #: redash/templates/emails/verify.html:5
 msgid "Hi"
 msgstr "Hallo"
-
-#: redash/templates/emails/invite.html:8
-msgid "invited you to join the Redash account of"
-msgstr "hat Sie eingeladen, dem Redash-Konto von beizutreten"
-
-#: redash/templates/emails/invite.html:10
-msgid "Setup Account"
-msgstr "Konto einrichten"
-
-#: redash/templates/emails/invite.html:12
-#: redash/templates/emails/verify.html:12
-msgid "You may copy/paste this link into your browser:"
-msgstr "Sie können diesen Link in Ihren Browser kopieren/einfügen:"
-
-#: redash/templates/emails/invite.html:15
-msgid "Your sign-in email is:"
-msgstr "Ihre Anmelde-E-Mail ist:"
-
-#: redash/templates/emails/invite.html:16
-msgid "Your Redash account is:"
-msgstr "Ihr Redash-Konto ist:"
-
-#: redash/templates/emails/reset.html:7
-msgid ""
-"You told us you forgot your password. If you really did, click here to "
-"choose a new one:"
-msgstr ""
-"Sie haben uns mitgeteilt, dass Sie Ihr Passwort vergessen haben. Wenn das"
-" wirklich der Fall ist, klicken Sie hier, um ein neues auszuwählen:"
-
-#: redash/templates/emails/reset.html:11
-msgid "Need the raw link?"
-msgstr "Benötigen Sie den Rohlink?"
-
-#: redash/templates/emails/reset.html:14
-msgid ""
-"If you didn't mean to reset your password, then you can just ignore this "
-"email; your password will not change."
-msgstr ""
-"Wenn Sie Ihr Passwort nicht zurücksetzen wollten, können Sie diese E-Mail"
-" einfach ignorieren; Ihr Passwort wird nicht geändert."
 
 #: redash/templates/emails/reset_disabled.html:7
 msgid ""
@@ -464,9 +418,10 @@ msgid ""
 " and therefore can't reset the password. Please contact your Redash admin"
 " for enabling again your account."
 msgstr ""
-"Sie haben eine E-Mail zum Zurücksetzen des Passworts angefordert, aber Ihr"
-" Redash-Konto ist deaktiviert und kann daher das Passwort nicht zurücksetzen."
-" Bitte wenden Sie sich an Ihren Redash-Administrator, um Ihr Konto wieder zu aktivieren."
+"Sie haben eine E-Mail zum Zurücksetzen des Passworts angefordert, aber "
+"Ihr Redash-Konto ist deaktiviert und kann daher das Passwort nicht "
+"zurücksetzen. Bitte wenden Sie sich an Ihren Redash-Administrator, um Ihr"
+" Konto wieder zu aktivieren."
 
 #: redash/templates/emails/verify.html:7
 msgid "Please verify that"
@@ -479,6 +434,10 @@ msgstr "Ihre korrekte E-Mail-Adresse ist, indem Sie den folgenden Link besuchen:
 #: redash/templates/emails/verify.html:10
 msgid "Verify Address"
 msgstr "Adresse verifizieren"
+
+#: redash/templates/emails/verify.html:12
+msgid "You may copy/paste this link into your browser:"
+msgstr "Sie können diesen Link in Ihren Browser kopieren/einfügen:"
 
 #: redash/utils/__init__.py:105
 msgid "JSON can't represent timezone-aware times."


### PR DESCRIPTION
This is part of the translation project , and the last one open before deploying the first part of translation.
We had some complication with the language feature flag and we are aiming to deploy this version without it.

## What type of PR is this? 

Here in this PR , i just roll back how we deal with the invite and reset emails since we have customized them earlier. I do this step before we deploy a first version of redash in German 

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually


I tested the "invite" and "reset password" processes , here are screenshots of the emails received 

<img width="560" alt="Screenshot 2024-12-11 at 17 49 25" src="https://github.com/user-attachments/assets/99cec7d8-cefa-4f5d-ba2a-8ffe82e1126e" />
<img width="557" alt="Screenshot 2024-12-11 at 17 49 41" src="https://github.com/user-attachments/assets/1fe145af-e398-41a4-a34b-e628782f288d" />

