### PR TITLE
update emails footer and logo

### DIFF
--- a/redash/templates/emails/invite.html
+++ b/redash/templates/emails/invite.html
@@ -27,11 +27,4 @@
     Freundliche Grüße<br>
     Ihr Team von metr
 </p>
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <br>
-    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    <br>
-    Kann man auf diese Mail antworten? <br>
-    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
-</p>
 {% endblock %}

--- a/redash/templates/emails/layout.html
+++ b/redash/templates/emails/layout.html
@@ -544,9 +544,9 @@ img.intercom-interblocks-article-author-avatar-image {
 
   <table width="100%" class="header" style="border-collapse: separate; border-spacing: 0; table-layout: fixed">
     <tr>
-      <td class="logo" style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; padding: 0; text-align: left" align="left">
+      <td class="logo" style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; padding: 0; text-align: right" align="right">
 
-          <img src="https://redash.io/assets/images/logo.png" width="165" height="86" class="featured" style="padding: 15px 0 30px; text-align: left">
+          <img src="https://dashboard-content.obs.eu-de.otc.t-systems.com/metr_logo_website.png" width="165" height="86" class="featured" style="padding: 15px 0 30px; text-align: right">
 
       </td>
     </tr>

--- a/redash/templates/emails/reset.html
+++ b/redash/templates/emails/reset.html
@@ -25,11 +25,4 @@
     Freundliche Grüße<br>
     Ihr Team von metr
 </p>
-<p class="intercom-align-left" style="line-height: 1.5; margin: 0 0 17px; text-align: left !important" align="left">
-    <br>
-    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    <br>
-    Kann man auf diese Mail antworten? <br>
-    Was ist oben für eine Grafik in der Mail? Ist das unser Logo? Dann müsste es nach rechts, falls das geht.
-</p>
 {% endblock %}


### PR DESCRIPTION
## What type of PR is this? 

- [x] Refactor


## Description

In this PR, we update the invite and reset emails to use our own logo (metr logo), we also make sure it appears on the right and we remove a  footer note that is not needed anymore

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually



## Related Tickets & Documents
- closes https://github.com/metr-systems/backlog/issues/3694
- follow up of https://github.com/metr-systems/redash/pull/24

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Here is how the reset-password emails look after the change (the invite one has also same changes )
<img width="575" alt="Screenshot 2024-12-12 at 12 12 02" src="https://github.com/user-attachments/assets/1a7b487c-922e-4e35-ba01-99f4d1c6f177" />
