### PR TITLE
return the default language directly

### DIFF
--- a/redash/app.py
+++ b/redash/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request
+from flask import Flask
 from flask_babel import Babel
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -24,8 +24,7 @@ class Redash(Flask):
 
 
 def get_locale():
-    # Todo UPDATE LATER TO RETUN SELECTED LOCALE FROM FLAG FEATURE
-    return request.accept_languages.best_match([settings.BABEL_DEFAULT_LOCALE])
+    return settings.BABEL_DEFAULT_LOCALE
 
 
 def create_app():


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix, related to[ sentry error ](https://metr-building-management-syste.sentry.io/issues/6135012933/events/5205cbc2891b4876993f624130c5022f/
)

## Description

Fixing an error we are having when scheduled tasks to send email about failing queries run.

So, apparently flask has two contexts, the app one and the request one ... here it seems to be about the request one. We just simplify the code and get the currently selected language from the env variable  `BABEL_DEFAULT_LOCALE`

## How is this tested?

- [x] Unit tests (pytest, jest)

...merging it right away because i need to deploy as a hotfix 