### PR TITLE
add translation for missed 'row' together with its plural

### DIFF
--- a/client/app/i18n/locales/de/Queries.json
+++ b/client/app/i18n/locales/de/Queries.json
@@ -82,6 +82,8 @@
   "Getting the data from your datasources.": "Abrufen der Daten aus Ihren Datenquellen.",
   "Result truncated to {{count}} rows. Databricks may truncate query results that are unstably large._one": "Das Ergebnis wurde auf {{count}} Zeilen gekürzt. Databricks kann Abfrageergebnisse kürzen, wenn diese zu groß sind.",
   "Result truncated to {{count}} rows. Databricks may truncate query results that are unstably large._other": "Das Ergebnis wurde auf {{count}} Zeilen gekürzt. Databricks kann Abfrageergebnisse kürzen, wenn diese zu groß sind.",
+  "row_one": "Zeile",
+  "row_other": "Zeilen",
   " runtime": " Laufzeit",
   "Running": "Läuft",
   "Data Scanned": "Daten gescannt",

--- a/client/app/i18n/locales/en/Queries.json
+++ b/client/app/i18n/locales/en/Queries.json
@@ -82,6 +82,8 @@
   "Getting the data from your datasources.": "",
   "Result truncated to {{count}} rows. Databricks may truncate query results that are unstably large._one": "",
   "Result truncated to {{count}} rows. Databricks may truncate query results that are unstably large._other": "",
+  "row_one": "row",
+  "row_other": "rows",
   " runtime": "",
   "Running": "",
   "Data Scanned": "",

--- a/client/app/pages/queries/components/QueryExecutionMetadata.jsx
+++ b/client/app/pages/queries/components/QueryExecutionMetadata.jsx
@@ -59,7 +59,7 @@ export default function QueryExecutionMetadata({
               </Tooltip>
             </span>
           )}
-          <strong>{queryResultData.rows.length}</strong> {pluralize("row", queryResultData.rows.length)}
+          <strong>{queryResultData.rows.length}</strong> {t("row", { count: queryResultData.rows.length })}
         </span>
         <span className="m-l-5">
           {!isQueryExecuting && (


### PR DESCRIPTION
## What type of PR is this? 

This PR adds/fix a missing translation on query detail page.
Related to the translation project : https://github.com/metr-systems/backlog/issues/3476

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually / on staging but i am testing the the alerts translation branch, so you will not find it there but i tested it there


