### PR TITLE
Add the title translation for the email that reports failed queries 

### DIFF
--- a/redash/locales/messages.pot
+++ b/redash/locales/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
+# Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-12-11 16:26+0100\n"
+"POT-Creation-Date: 2025-01-08 14:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -229,6 +229,10 @@ msgstr ""
 msgid ""
 "You cannot disable your own account. Please ask another admin to do this "
 "for you."
+msgstr ""
+
+#: redash/tasks/failure_report.py:59
+msgid "Redash failed to execute {count} of your scheduled queries"
 msgstr ""
 
 #: redash/templates/error.html:5

--- a/redash/tasks/failure_report.py
+++ b/redash/tasks/failure_report.py
@@ -2,6 +2,8 @@ import datetime
 import re
 from collections import Counter
 
+from flask_babel import _
+
 from redash import models, redis_connection, settings
 from redash.tasks.general import send_mail
 from redash.utils import base_url, json_dumps, json_loads, render_template
@@ -54,7 +56,9 @@ def send_failure_report(user_id):
             "base_url": base_url(user.org),
         }
 
-        subject = f"Redash failed to execute {len(unique_errors.keys())} of your scheduled queries"
+        subject = _("Redash failed to execute {count} of your scheduled queries").format(
+            count=len(unique_errors.keys())
+        )
         html, text = [
             render_template("emails/failures.{}".format(f), context)
             for f in ["html", "txt"]

--- a/redash/translations/de/LC_MESSAGES/messages.po
+++ b/redash/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Redash 10.0.0\n"
 "Report-Msgid-Bugs-To: engineering@metr.systems\n"
-"POT-Creation-Date: 2024-12-11 16:26+0100\n"
+"POT-Creation-Date: 2025-01-08 14:52+0100\n"
 "PO-Revision-Date: 2024-12-04 15:21+0100\n"
 "Last-Translator: metr Building Management Systems team "
 "<engineering@metr.systems>\n"
@@ -254,6 +254,10 @@ msgid ""
 msgstr ""
 "Sie können Ihr eigenes Konto nicht deaktivieren. Bitte bitten Sie einen "
 "anderen Administrator, dies für Sie zu tun."
+
+#: redash/tasks/failure_report.py:59
+msgid "Redash failed to execute {count} of your scheduled queries"
+msgstr "Redash konnte {count} Ihrer geplanten Abfragen nicht ausführen."
 
 #: redash/templates/error.html:5
 msgid "Error"

--- a/tests/tasks/test_failure_report.py
+++ b/tests/tasks/test_failure_report.py
@@ -53,13 +53,15 @@ class TestSendAggregatedErrorsTask(BaseTestCase):
         email_pending = redis_connection.exists(key)
         self.assertFalse(email_pending)
 
-    def test_does_not_indicate_when_not_near_limit_for_a_query(self):
+    @mock.patch("redash.tasks.failure_report._", side_effect=lambda x: x)
+    def test_does_not_indicate_when_not_near_limit_for_a_query(self, mock_translation):
         self.notify(schedule_failures=settings.MAX_FAILURE_REPORTS_PER_QUERY / 2)
         failures = self.send_email(self.factory.user)
 
         self.assertFalse(failures[0]["comment"])
 
-    def test_indicates_when_near_limit_for_a_query(self):
+    @mock.patch("redash.tasks.failure_report._", side_effect=lambda x: x)
+    def test_indicates_when_near_limit_for_a_query(self, mock_translation):
         self.notify(schedule_failures=settings.MAX_FAILURE_REPORTS_PER_QUERY - 1)
         failures = self.send_email(self.factory.user)
 
@@ -71,7 +73,8 @@ class TestSendAggregatedErrorsTask(BaseTestCase):
 
         self.assertEqual(key1, key2)
 
-    def test_counts_failures_for_each_reason(self):
+    @mock.patch("redash.tasks.failure_report._", side_effect=lambda x: x)
+    def test_counts_failures_for_each_reason(self, mock_translation):
         query = self.factory.create_query()
 
         self.notify(message="I'm a failure", query=query)
@@ -88,7 +91,8 @@ class TestSendAggregatedErrorsTask(BaseTestCase):
         f3 = next(f for f in failures if f["failure_reason"] == "I'm a totally different query")
         self.assertEqual(1, f3["failure_count"])
 
-    def test_shows_latest_failure_time(self):
+    @mock.patch("redash.tasks.failure_report._", side_effect=lambda x: x)
+    def test_shows_latest_failure_time(self, mock_translation):
         query = self.factory.create_query()
 
         with freeze_time("2000-01-01"):


### PR DESCRIPTION
## What type of PR is this? 

the email that reports failed queries has its detail translated but its title has been missed , in this PR I add its translation and fix related tests.
I did not test this manually on staging since i will need to schedule emails that report failed queries and i don't want to invest a lot of time on it but it is a small change and it should work

Related to the translation project : https://github.com/metr-systems/backlog/issues/3476

## How is this tested?

- [x] Unit tests (pytest, jest)

