### PR TITLE
make sure parameters are disabled during dashboard refresh

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -28,6 +28,7 @@ class ParameterValueInput extends React.Component {
     parameter: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     onSelect: PropTypes.func,
     className: PropTypes.string,
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ class ParameterValueInput extends React.Component {
     parameter: null,
     onSelect: () => {},
     className: "",
+    disabled: false,
   };
 
   constructor(props) {
@@ -50,7 +52,6 @@ class ParameterValueInput extends React.Component {
 
   componentDidUpdate = prevProps => {
     const { value, parameter } = this.props;
-    // if value prop updated, reset dirty state
     if (prevProps.value !== value || prevProps.parameter !== parameter) {
       this.setState({
         value: parameter.hasPendingValue ? parameter.pendingValue : value,
@@ -60,13 +61,14 @@ class ParameterValueInput extends React.Component {
   };
 
   onSelect = value => {
+    if (this.props.disabled) return; // Prevent onSelect if disabled
     const isDirty = !isEqual(value, this.props.value);
     this.setState({ value, isDirty });
     this.props.onSelect(value, isDirty);
   };
 
   renderDateParameter() {
-    const { type, parameter } = this.props;
+    const { type, parameter, disabled } = this.props;
     const { value } = this.state;
     return (
       <DateParameter
@@ -75,12 +77,13 @@ class ParameterValueInput extends React.Component {
         value={value}
         parameter={parameter}
         onSelect={this.onSelect}
+        disabled={disabled}
       />
     );
   }
 
   renderDateRangeParameter() {
-    const { type, parameter } = this.props;
+    const { type, parameter, disabled } = this.props;
     const { value } = this.state;
     return (
       <DateRangeParameter
@@ -89,15 +92,15 @@ class ParameterValueInput extends React.Component {
         value={value}
         parameter={parameter}
         onSelect={this.onSelect}
+        disabled={disabled}
       />
     );
   }
 
   renderEnumInput() {
-    const { enumOptions, parameter } = this.props;
+    const { enumOptions, parameter, disabled } = this.props;
     const { value } = this.state;
     const enumOptionsArray = enumOptions.split("\n").filter(v => v !== "");
-    // Antd Select doesn't handle null in multiple mode
     const normalize = val => (parameter.multiValuesOptions && val === null ? [] : val);
 
     return (
@@ -109,14 +112,14 @@ class ParameterValueInput extends React.Component {
         options={map(enumOptionsArray, opt => ({ label: String(opt), value: opt }))}
         showSearch
         showArrow
+        disabled={disabled}
         notFoundContent={isEmpty(enumOptionsArray) ? i18next.t("Params:No options available") : null}
-        {...multipleValuesProps}
       />
     );
   }
 
   renderQueryBasedInput() {
-    const { queryId, parameter } = this.props;
+    const { queryId, parameter, disabled } = this.props;
     const { value } = this.state;
     return (
       <QueryBasedParameterInput
@@ -127,13 +130,13 @@ class ParameterValueInput extends React.Component {
         queryId={queryId}
         onSelect={this.onSelect}
         style={{ minWidth: 60 }}
-        {...multipleValuesProps}
+        disabled={disabled}
       />
     );
   }
 
   renderNumberInput() {
-    const { className } = this.props;
+    const { className, disabled } = this.props;
     const { value } = this.state;
 
     const normalize = val => (isNaN(val) ? undefined : val);
@@ -144,12 +147,13 @@ class ParameterValueInput extends React.Component {
         value={normalize(value)}
         aria-label={i18next.t("Params:Parameter number value")}
         onChange={val => this.onSelect(normalize(val))}
+        disabled={disabled}
       />
     );
   }
 
   renderTextInput() {
-    const { className } = this.props;
+    const { className, disabled } = this.props;
     const { value } = this.state;
 
     return (
@@ -159,6 +163,7 @@ class ParameterValueInput extends React.Component {
         aria-label={i18next.t("Params:Parameter text value")}
         data-test="TextParamInput"
         onChange={e => this.onSelect(e.target.value)}
+        disabled={disabled}
       />
     );
   }

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -28,6 +28,7 @@ export default class Parameters extends React.Component {
     parameters: PropTypes.arrayOf(PropTypes.instanceOf(Parameter)),
     editable: PropTypes.bool,
     sortable: PropTypes.bool,
+    disabled: PropTypes.bool,
     disableUrlUpdate: PropTypes.bool,
     onValuesChange: PropTypes.func,
     onPendingValuesChange: PropTypes.func,
@@ -138,7 +139,7 @@ export default class Parameters extends React.Component {
     if (this.hideValues.some(value => this.toCamelCase(value) === this.toCamelCase(param.name))) {
       return null;
     }
-    const { editable } = this.props;
+    const { editable, disabled } = this.props;
     if (param.hidden) {
       return null;
     }
@@ -165,6 +166,7 @@ export default class Parameters extends React.Component {
           enumOptions={param.enumOptions}
           queryId={param.queryId}
           onSelect={(value, isDirty) => this.setPendingValue(param, value, isDirty)}
+          disabled={disabled}
         />
       </div>
     );

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -82,6 +82,7 @@ function DashboardComponent(props) {
     dashboard,
     filters,
     setFilters,
+    refreshing,
     loadDashboard,
     loadWidget,
     removeWidget,
@@ -143,6 +144,7 @@ function DashboardComponent(props) {
             onValuesChange={refreshDashboard}
             sortable={editingLayout}
             onParametersEdit={onParametersEdit}
+            disabled={refreshing} // Disable parameters when refreshing
           />
         </div>
       )}


### PR DESCRIPTION
closes https://github.com/metr-systems/backlog/issues/3610

## What type of PR is this? 

- [x] Bug Fix

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcHRhbHY3OWd2cDVoaDg4M3BqemFod211b3YzM3Fpczd2c3htY3FvaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgNPVbGsa0Wd8li/giphy.gif)

## Description

We have some queries that take a long time to execute , so the related widgets take a long time to refresh. This causes a weird behavior because the user may update the parameters while the widgets are still getting refreshed, in this case these widgets at the end will show the old values related to the first change and that is an issue.

This pull request introduces a new `disabled` prop that makes sure that the parameters update is disabled while the dashboard is still `refreshing` .

In order to fulfil this , we needed to do that at three levels


### First level : `DashboardComponent`:

* Added `refreshing` prop to `DashboardComponent` function parameters that we get from `dashboardConfiguration`.
* Passed `refreshing` prop as `disabled` to `Parameters` component to disable parameters while refreshing.




### Second level : `Parameters` component:

* Added `disabled` prop to `Parameters` component's `propTypes`.
* Passed `disabled` prop to `ParameterValueInput` component within `Parameters` component.



### Third level :  `ParameterValueInput` component:

* Added `disabled` prop to `ParameterValueInput` component's `propTypes` and `defaultProps`. 
* Updated `onSelect` method to prevent selection when `disabled` is true.
* Passed `disabled` prop to various child components like `DateParameter`, `DateRangeParameter`, `EnumInput`, `QueryBasedParameterInput`, `NumberInput`, and `TextInput`. In order to make sure this applies to all the inputs types


## How is this tested?

- [x] Manually


## UI changes

You can check how this works on [staging](https://dashboard.staging.metr.systems/staging/dashboards/23-testrefresh?p_first_param=1&p_second_param=2) 
