### PR TITLE
remove height:inherit from table visualization

### DIFF
--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -130,9 +130,6 @@
     width: 100%;
     height: 100%;
 
-    & div {
-      height: inherit;
-    }
 
     .ant-spin-container {
       display: flex;


### PR DESCRIPTION
closes https://github.com/metr-systems/backlog/issues/3655

## What type of PR is this? 

- [x] Bug Fix


## Description

The `height: inherit` LESS rule was affecting the appearance of widget tables, sometimes causing text to appear blurry. This happened because the rule inherited proportional values from parent divs in certain cases.

Since the rule was applied only to table widgets, it should not impact any other widget.

Removing it does seem to work. You can check the results here: https://dashboard.staging.metr.systems/staging/dashboards/24-test-dashboard-table-size , you can zoom-in and ou to make sure that the text won't get blurry 


FYI: I commented on the open redash related issue with this solution and asked them if there is any reason they did not got for it https://github.com/getredash/redash/issues/5505#issuecomment-2684469280