### PR TITLE
Affect user to group at creation

### DIFF
--- a/client/app/i18n/locales/de/Users.json
+++ b/client/app/i18n/locales/de/Users.json
@@ -4,6 +4,7 @@
   "Regenerate": "Neu generieren",
   "API Key": "API-Schlüssel",
   "Create a New User": "Neuen Benutzer erstellen",
+  "Loading groups": "Gruppen werden geladen",
   "This field is required.": "Dieses Feld ist erforderlich.",
   "This field is too short.": "Dieses Feld ist zu kurz.",
   "Passwords don't match": "Die Passwörter stimmen nicht überein",

--- a/client/app/i18n/locales/en/Users.json
+++ b/client/app/i18n/locales/en/Users.json
@@ -4,6 +4,7 @@
   "Regenerate": "Regenerate",
   "API Key": "API Key",
   "Create a New User": "Create a New User",
+  "Loading groups": "Loading groups",
   "This field is required.": "This field is required.",
   "This field is too short.": "This field is too short.",
   "Passwords don't match": "Passwords don't match",

--- a/client/app/pages/users/components/CreateUserDialog.jsx
+++ b/client/app/pages/users/components/CreateUserDialog.jsx
@@ -69,7 +69,7 @@ function CreateUserDialog({ dialog }) {
       {!loading ? (
         <DynamicForm id={formId} fields={formFields} onSubmit={handleSubmit} hideSubmitButton />
       ) : (
-        <p>Loading groups...</p>
+        <p>{i18next.t("Users:Loading groups")}...</p>
       )}
       {error && <Alert message={error.message} type="error" showIcon data-test="CreateUserErrorAlert" />}
     </Modal>

--- a/client/app/pages/users/components/CreateUserDialog.jsx
+++ b/client/app/pages/users/components/CreateUserDialog.jsx
@@ -9,17 +9,38 @@ import DynamicForm from "@/components/dynamic-form/DynamicForm";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import recordEvent from "@/services/recordEvent";
 import { useUniqueId } from "@/lib/hooks/useUniqueId";
-
-const formFields = [
-  { required: true, name: "name", title: "Name", type: "text", autoFocus: true },
-  { required: true, name: "email", title: "Email", type: "email" },
-];
+import axios from "axios";
 
 function CreateUserDialog({ dialog }) {
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [groups, setGroups] = useState([]);
+
   useEffect(() => {
     recordEvent("view", "page", "users/new");
+
+    axios
+      .get("/api/groups")
+      .then(response => {
+        const groupOptions = response.data.map(group => ({ name: group.name, value: group.id }));
+        setGroups(groupOptions);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   }, []);
+
+  // Dynamically update the form fields with the fetched groups
+  const formFields = [
+    { required: true, name: "name", title: "Name", type: "text", autoFocus: true },
+    { required: true, name: "email", title: "Email", type: "email" },
+    {
+      required: true,
+      name: "group_id",
+      title: "Group",
+      type: "select",
+      options: groups, // Now it updates when groups change
+    },
+  ];
 
   const handleSubmit = useCallback(values => dialog.close(values).catch(setError), [dialog]);
   const formId = useUniqueId("userForm");
@@ -45,7 +66,11 @@ function CreateUserDialog({ dialog }) {
       wrapProps={{
         "data-test": "CreateUserDialog",
       }}>
-      <DynamicForm id={formId} fields={formFields} onSubmit={handleSubmit} hideSubmitButton />
+      {!loading ? (
+        <DynamicForm id={formId} fields={formFields} onSubmit={handleSubmit} hideSubmitButton />
+      ) : (
+        <p>Loading groups...</p>
+      )}
       {error && <Alert message={error.message} type="error" showIcon data-test="CreateUserErrorAlert" />}
     </Modal>
   );

--- a/client/app/pages/users/components/CreateUserDialog.jsx
+++ b/client/app/pages/users/components/CreateUserDialog.jsx
@@ -9,7 +9,7 @@ import DynamicForm from "@/components/dynamic-form/DynamicForm";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import recordEvent from "@/services/recordEvent";
 import { useUniqueId } from "@/lib/hooks/useUniqueId";
-import axios from "axios";
+import Group from "@/services/group";
 
 function CreateUserDialog({ dialog }) {
   const [error, setError] = useState(null);
@@ -19,14 +19,11 @@ function CreateUserDialog({ dialog }) {
   useEffect(() => {
     recordEvent("view", "page", "users/new");
 
-    axios
-      .get("/api/groups")
-      .then(response => {
-        const groupOptions = response.data.map(group => ({ name: group.name, value: group.id }));
-        setGroups(groupOptions);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
+    Group.query().then(groups => {
+      const groupOptions = groups.map(group => ({ name: group.name, value: group.id }));
+      setGroups(groupOptions);
+      setLoading(false);
+    });
   }, []);
 
   // Dynamically update the form fields with the fetched groups

--- a/client/app/pages/users/components/CreateUserDialog.jsx
+++ b/client/app/pages/users/components/CreateUserDialog.jsx
@@ -11,33 +11,36 @@ import recordEvent from "@/services/recordEvent";
 import { useUniqueId } from "@/lib/hooks/useUniqueId";
 import Group from "@/services/group";
 
+const baseFormFields = [
+  { required: true, name: "name", title: "Name", type: "text", autoFocus: true },
+  { required: true, name: "email", title: "Email", type: "email" },
+];
+
 function CreateUserDialog({ dialog }) {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [groups, setGroups] = useState([]);
+  const [formFields, setFormFields] = useState(baseFormFields);
 
   useEffect(() => {
     recordEvent("view", "page", "users/new");
 
     Group.query().then(groups => {
       const groupOptions = groups.map(group => ({ name: group.name, value: group.id }));
-      setGroups(groupOptions);
+
+      setFormFields([
+        ...baseFormFields,
+        {
+          required: true,
+          name: "group_id",
+          title: "Group",
+          type: "select",
+          options: groupOptions,
+        },
+      ]);
+
       setLoading(false);
     });
   }, []);
-
-  // Dynamically update the form fields with the fetched groups
-  const formFields = [
-    { required: true, name: "name", title: "Name", type: "text", autoFocus: true },
-    { required: true, name: "email", title: "Email", type: "email" },
-    {
-      required: true,
-      name: "group_id",
-      title: "Group",
-      type: "select",
-      options: groups, // Now it updates when groups change
-    },
-  ];
 
   const handleSubmit = useCallback(values => dialog.close(values).catch(setError), [dialog]);
   const formId = useUniqueId("userForm");

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -140,7 +140,7 @@ class UserListResource(BaseResource):
         # Validate group ID
         group = models.Group.query.get(req["group_id"])
         if not group:
-            abort(400, message="Invalid group selected.")
+            abort(400, message=_("Invalid group selected."))
 
         user = models.User(
             org=self.current_org,

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -131,18 +131,23 @@ class UserListResource(BaseResource):
     @require_admin
     def post(self):
         req = request.get_json(force=True)
-        require_fields(req, ("name", "email"))
+        require_fields(req, ("name", "email", "group_id"))
 
         if "@" not in req["email"]:
             abort(400, message=_("Bad email address."))
         require_allowed_email(req["email"])
+
+        # Validate group ID
+        group = models.Group.query.get(req["group_id"])
+        if not group:
+            abort(400, message="Invalid group selected.")
 
         user = models.User(
             org=self.current_org,
             name=req["name"],
             email=req["email"],
             is_invitation_pending=True,
-            group_ids=[self.current_org.default_group.id],
+            group_ids=[group.id],
         )
 
         try:

--- a/redash/locales/messages.pot
+++ b/redash/locales/messages.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2025-01-24 11:28+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2025-03-05 13:47+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -208,7 +208,10 @@ msgstr ""
 msgid "Bad email address."
 msgstr ""
 
-#: redash/handlers/users.py:153 redash/handlers/users.py:260
+#: redash/handlers/users.py:143
+msgid "Invalid group selected."
+msgstr ""
+
 msgid "Email already taken."
 msgstr ""
 

--- a/redash/translations/de/LC_MESSAGES/messages.po
+++ b/redash/translations/de/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Redash 10.0.0\n"
 "Report-Msgid-Bugs-To: engineering@metr.systems\n"
 "POT-Creation-Date: 2025-01-24 11:28+0100\n"
-"PO-Revision-Date: 2024-12-04 15:21+0100\n"
+"PO-Revision-Date: 2025-03-05 13:47+0100\n"
 "Last-Translator: metr Building Management Systems team "
 "<engineering@metr.systems>\n"
 "Language: de\n"
@@ -225,7 +225,10 @@ msgstr "Organisationsname"
 msgid "Bad email address."
 msgstr "Ungültige E-Mail-Adresse."
 
-#: redash/handlers/users.py:153 redash/handlers/users.py:260
+#: redash/handlers/users.py:143
+msgid "Invalid group selected."
+msgstr "Ungültige Gruppe ausgewählt."
+
 msgid "Email already taken."
 msgstr "E-Mail bereits vergeben."
 

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -26,10 +26,21 @@ class TestUserListResourcePost(BaseTestCase):
         )
         self.assertEqual(rv.status_code, 400)
 
+        rv = self.make_request(
+            "post",
+            "/api/users",
+            data={"name": "User", "email": "email@gmail.com", "password": "test"},
+            user=admin,
+        )  # missing group_id
+        self.assertEqual(rv.status_code, 400)
+
     def test_returns_400_when_using_temporary_email(self):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": "user@mailinator.com", "password": "test"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": "user@mailinator.com", "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
         self.assertEqual(rv.status_code, 400)
 
@@ -40,7 +51,10 @@ class TestUserListResourcePost(BaseTestCase):
     def test_creates_user(self):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": "user@example.com", "password": "test"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": "user@example.com", "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
 
         self.assertEqual(rv.status_code, 200)
@@ -51,7 +65,10 @@ class TestUserListResourcePost(BaseTestCase):
     def test_shows_invite_link_when_email_is_not_configured(self, _):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": "user@example.com"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": "user@example.com", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
 
         self.assertEqual(rv.status_code, 200)
@@ -61,7 +78,10 @@ class TestUserListResourcePost(BaseTestCase):
     def test_does_not_show_invite_link_when_email_is_configured(self, _):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": "user@example.com"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": "user@example.com", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
 
         self.assertEqual(rv.status_code, 200)
@@ -70,7 +90,10 @@ class TestUserListResourcePost(BaseTestCase):
     def test_creates_user_case_insensitive_email(self):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": "User@Example.com", "password": "test"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": "User@Example.com", "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
 
         self.assertEqual(rv.status_code, 200)
@@ -80,7 +103,10 @@ class TestUserListResourcePost(BaseTestCase):
     def test_returns_400_when_email_taken(self):
         admin = self.factory.create_admin()
 
-        test_user = {"name": "User", "email": admin.email, "password": "test"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user = {"name": "User", "email": admin.email, "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user, user=admin)
 
         self.assertEqual(rv.status_code, 400)
@@ -88,13 +114,16 @@ class TestUserListResourcePost(BaseTestCase):
     def test_returns_400_when_email_taken_case_insensitive(self):
         admin = self.factory.create_admin()
 
-        test_user1 = {"name": "User", "email": "user@example.com", "password": "test"}
+        group_id = 5
+        self.factory.create_group(id=group_id)
+
+        test_user1 = {"name": "User", "email": "user@example.com", "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user1, user=admin)
 
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.json["email"], "user@example.com")
 
-        test_user2 = {"name": "User", "email": "user@Example.com", "password": "test"}
+        test_user2 = {"name": "User", "email": "user@Example.com", "password": "test", "group_id": group_id}
         rv = self.make_request("post", "/api/users", data=test_user2, user=admin)
 
         self.assertEqual(rv.status_code, 400)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature


## Description

closes https://github.com/metr-systems/backlog/issues/3793

In redash, the usual way is ,to create a user account and it gets automatically affected to the default group. Later on, the admin can update that account and give it another group ...

In this PR , we make sure we can affect user to a custom group when creating the account. This, in order to make the process better and also, to make sure the custom user does not get any unwanted access even for a short time.

## How is this tested?

- [x] Unit tests (pytest) Just the backend
- [x] Manually


## Related Tickets & Documents

Part of the project about redash dashboard permissions : https://github.com/orgs/metr-systems/projects/32

Note: Staging has been updated with these changes

closes https://github.com/metr-systems/backlog/issues/3793