### PR TITLE
make sure default group has access to new dashboard

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -99,7 +99,12 @@ class DashboardListResource(BaseResource):
             is_draft=True,
             layout=[],
         )
+
+        default_group = self.current_org.default_group
+        dashboard_group = models.DashboardGroup(dashboard=dashboard, group=default_group)
+
         models.db.session.add(dashboard)
+        models.db.session.add(dashboard_group)
         models.db.session.commit()
         return DashboardSerializer(dashboard).serialize()
 

--- a/tests/handlers/test_dashboards.py
+++ b/tests/handlers/test_dashboards.py
@@ -1,4 +1,4 @@
-from redash.models import AccessPermission, ApiKey, Dashboard, db
+from redash.models import AccessPermission, ApiKey, Dashboard, DashboardGroup, db
 from redash.permissions import ACCESS_TYPE_MODIFY
 from redash.serializers import serialize_dashboard
 from redash.utils import json_loads
@@ -13,6 +13,15 @@ class TestDashboardListResource(BaseTestCase):
         self.assertEqual(rv.json["name"], "Test Dashboard")
         self.assertEqual(rv.json["user_id"], self.factory.user.id)
         self.assertEqual(rv.json["layout"], [])
+
+    def test_default_group_has_access_to_new_dashboard(self):
+        dashboard_name = "Test Dashboard"
+        rv = self.make_request("post", "/api/dashboards", data={"name": dashboard_name})
+        self.assertEqual(rv.status_code, 200)
+        dashboard = Dashboard.get_by_id_and_org(rv.json["id"], self.factory.org)
+        dashboard_group = DashboardGroup.query.filter(DashboardGroup.dashboard == dashboard).first()
+        self.assertIsNotNone(dashboard_group)
+        self.assertEqual(dashboard_group.group, self.factory.org.default_group)
 
 
 class TestDashboardListGetResource(BaseTestCase):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

Closes https://github.com/metr-systems/backlog/issues/3797

Before adding the code that controls access, we want to make sure every new dashboard that will be created will be able to be accessed by the default group members. 

In this PR, we make this happen by creating the instance DashboardGroup(new dashboard, default group)

## How is this tested?

- [x] Unit tests (pytest)
- [x] Manually - In local only


## Related Tickets & Documents

Part of the project about redash dashboard permissions : https://github.com/orgs/metr-systems/projects/32
Closes https://github.com/metr-systems/backlog/issues/3797

