### PR TITLE
Hide settings link for custom user

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -67,8 +67,6 @@ function useNavbarActiveState() {
 
 export default function DesktopNavbar() {
   const { t } = useTranslation("ApplicationArea");
-  const canSeeSettings =
-    currentUser.is_default || currentUser.hasPermission("admin") || currentUser.hasPermission("super_admin");
   const firstSettingsTab = first(settingsMenu.getAvailableItems());
 
   const activeState = useNavbarActiveState();
@@ -159,7 +157,7 @@ export default function DesktopNavbar() {
             <span className="desktop-navbar-label">{t("Help")}</span>
           </HelpTrigger>
         </Menu.Item>
-        {firstSettingsTab && canSeeSettings && (
+        {firstSettingsTab && currentUser.canViewSettings() && (
           <Menu.Item key="settings" className={activeState.dataSources ? "navbar-active-item" : null}>
             <Link href={firstSettingsTab.path} data-test="SettingsLink">
               <SettingOutlinedIcon />

--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -67,7 +67,8 @@ function useNavbarActiveState() {
 
 export default function DesktopNavbar() {
   const { t } = useTranslation("ApplicationArea");
-
+  const canSeeSettings =
+    currentUser.is_default || currentUser.hasPermission("admin") || currentUser.hasPermission("super_admin");
   const firstSettingsTab = first(settingsMenu.getAvailableItems());
 
   const activeState = useNavbarActiveState();
@@ -158,7 +159,7 @@ export default function DesktopNavbar() {
             <span className="desktop-navbar-label">{t("Help")}</span>
           </HelpTrigger>
         </Menu.Item>
-        {firstSettingsTab && (
+        {firstSettingsTab && canSeeSettings && (
           <Menu.Item key="settings" className={activeState.dataSources ? "navbar-active-item" : null}>
             <Link href={firstSettingsTab.path} data-test="SettingsLink">
               <SettingOutlinedIcon />

--- a/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
@@ -17,8 +17,6 @@ import "./MobileNavbar.less";
 
 export default function MobileNavbar({ getPopupContainer }) {
   const { t } = useTranslation("ApplicationArea");
-  const canSeeSettings =
-    currentUser.is_default || currentUser.hasPermission("admin") || currentUser.hasPermission("super_admin");
   const firstSettingsTab = first(settingsMenu.getAvailableItems());
 
   return (
@@ -54,7 +52,7 @@ export default function MobileNavbar({ getPopupContainer }) {
                 <Link href="users/me">{t("Edit Profile")}</Link>
               </Menu.Item>
               <Menu.Divider />
-              {firstSettingsTab && canSeeSettings && (
+              {firstSettingsTab && currentUser.canViewSettings() && (
                 <Menu.Item key="settings">
                   <Link href={firstSettingsTab.path}>{t("Settings")}</Link>
                 </Menu.Item>

--- a/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
@@ -17,7 +17,8 @@ import "./MobileNavbar.less";
 
 export default function MobileNavbar({ getPopupContainer }) {
   const { t } = useTranslation("ApplicationArea");
-
+  const canSeeSettings =
+    currentUser.is_default || currentUser.hasPermission("admin") || currentUser.hasPermission("super_admin");
   const firstSettingsTab = first(settingsMenu.getAvailableItems());
 
   return (
@@ -53,7 +54,7 @@ export default function MobileNavbar({ getPopupContainer }) {
                 <Link href="users/me">{t("Edit Profile")}</Link>
               </Menu.Item>
               <Menu.Divider />
-              {firstSettingsTab && (
+              {firstSettingsTab && canSeeSettings && (
                 <Menu.Item key="settings">
                   <Link href={firstSettingsTab.path}>{t("Settings")}</Link>
                 </Menu.Item>

--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -22,6 +22,10 @@ export const currentUser = {
     return this.hasPermission("super_admin") || this.hasPermission("admin") || this.hasPermission("view_query");
   },
 
+  canViewSettings() {
+    return this.is_default || this.hasPermission("admin") || this.hasPermission("super_admin");
+  },
+
   hasPermission(permission) {
     if (permission === "admin" && this._isAdmin !== undefined) {
       return this._isAdmin;

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -319,6 +319,7 @@ def session(org_slug=None):
             "email": current_user.email,
             "groups": current_user.group_ids,
             "permissions": current_user.permissions,
+            "is_default": current_user.is_default,
         }
 
     return json_response(

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -116,6 +116,13 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
         super(User, self).__init__(*args, **kwargs)
 
     @property
+    def is_default(self):
+        """
+        Returns True if the user is part of the default group for the organization.
+        """
+        return self.org.default_group.id in self.group_ids
+
+    @property
     def is_disabled(self):
         return self.disabled_at is not None
 
@@ -145,6 +152,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
             "created_at": self.created_at,
             "disabled_at": self.disabled_at,
             "is_disabled": self.is_disabled,
+            "is_default": self.is_default,
             "active_at": self.active_at,
             "is_invitation_pending": self.is_invitation_pending,
             "is_email_verified": self.is_email_verified,


### PR DESCRIPTION
## What type of PR is this? 

- [x] Refactor

## Description

In this PR we hide the settings link in the nav bar for custom users and only show it for default or admin users.

## How is this tested?

- [x] Manually (the web only not the mobile one / deployed to staging)

## Related Tickets & Documents

Part of https://github.com/metr-systems/backlog/issues/3818


