### PR TITLE
Always use all the parameters to filter widgets

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -136,8 +136,8 @@ function useDashboard(dashboardData) {
   const loadDashboard = useCallback(
     (forceRefresh = false, updatedParameters = []) => {
       // get the values of the parameters
-      const widgetFilterParams = updatedParameters.length > 0 ? updatedParameters : globalParameters;
 
+      const widgetFilterParams = globalParameters;
       // filter widgets to show from all the widgets according to the current parameters
       dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(
         widgetFilterParams,


### PR DESCRIPTION
The `getAllowedWidgetsForCurrentParam` iterates over the parameters to check which widget to show or hide.

For that, we always need every parameter of the dashboard, not only those that have changed value.

This is online at https://dashboard.staging.metr.systems/staging/dashboards/1-test?p_parameter=123-a&p_total=10

You can change the first parameter to show/hide the widgets and the second to test the data changing without the widgets to show back.

