### PR TITLE
Update state when changing the widgets

### DIFF
--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -95,6 +95,7 @@ function DashboardComponent(props) {
     editedlayoutsOrder,
     setEditedlayoutsOrder,
     setGridDisabled,
+    visibleWidgets
   } = dashboardConfiguration;
 
   const [pageContainer, setPageContainer] = useState(null);
@@ -157,7 +158,7 @@ function DashboardComponent(props) {
       <div id="dashboard-container">
         <DashboardGrid
           dashboard={dashboard}
-          widgets={dashboard.widgets}
+          widgets={visibleWidgets}
           filters={filters}
           editedlayoutsOrder={editedlayoutsOrder}
           setEditedlayoutsOrder={setEditedlayoutsOrder}

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -43,6 +43,7 @@ function useDashboard(dashboardData) {
   const { t } = useTranslation("Dashboards");
   const [dashboard, setDashboard] = useState(dashboardData);
   const [filters, setFilters] = useState([]);
+  const [visibleWidgets, setVisibleWidgets] = useState([]);
   const [refreshing, setRefreshing] = useState(false);
   const [gridDisabled, setGridDisabled] = useState(false);
   const globalParameters = useMemo(() => dashboard.getParametersDefs(), [dashboard]);
@@ -137,15 +138,16 @@ function useDashboard(dashboardData) {
     (forceRefresh = false, updatedParameters = []) => {
       // get the values of the parameters
 
-      const widgetFilterParams = globalParameters;
       // filter widgets to show from all the widgets according to the current parameters
-      dashboardRef.current.widgets = getAllowedWidgetsForCurrentParam(
-        widgetFilterParams,
+      const allowedWidgets = getAllowedWidgetsForCurrentParam(
+        globalParameters,
         dashboardRef.current.allowed_widgets,
         dashboardRef.current.saved_all_widgets
       );
+      setVisibleWidgets(allowedWidgets);
 
-      const affectedWidgets = getAffectedWidgets(dashboardRef.current.widgets, updatedParameters);
+
+      const affectedWidgets = getAffectedWidgets(allowedWidgets, updatedParameters);
       const loadWidgetPromises = compact(
         affectedWidgets.map(widget => loadWidget(widget, forceRefresh).catch(error => error))
       );
@@ -156,7 +158,7 @@ function useDashboard(dashboardData) {
         setFilters(updatedFilters);
       });
     },
-    [globalParameters, loadWidget]
+    [globalParameters, loadWidget, dashboardRef]
   );
 
   const refreshDashboard = useCallback(
@@ -270,6 +272,7 @@ function useDashboard(dashboardData) {
     managePermissions,
     isDuplicating,
     duplicateDashboard,
+    visibleWidgets
   };
 }
 


### PR DESCRIPTION
We can't change the dashboardRef properties because it doesn't trigger a refresh. To fix that I'm now using the useState hook to update the widgets displayed

This is already deployed and ready for review in staging.
