### PR TITLE
show all possible dashboards to be add to a group

### DIFF
--- a/client/app/pages/groups/GroupDashboards.jsx
+++ b/client/app/pages/groups/GroupDashboards.jsx
@@ -104,7 +104,29 @@ class GroupDashboards extends React.Component {
   };
 
   addDashboards = () => {
-    const allDashboards = DashboardEndpoints.query();
+    const fetchAllDashboards = async () => {
+      const dashboards = [];
+
+      // Fetch the first page
+      let response = await DashboardEndpoints.query();
+
+      dashboards.push(...response.results);
+
+      let currentPage = response.page;
+      const totalPages = Math.ceil(response.count / response.page_size);
+
+      // Fetch the remaining pages
+      while (currentPage < totalPages) {
+        currentPage += 1;
+        response = await DashboardEndpoints.query({ page: currentPage });
+        dashboards.push(...response.results);
+      }
+
+      return { results: dashboards };
+    };
+
+    const allDashboards = fetchAllDashboards();
+
     const alreadyAddedDashboards = map(this.props.controller.allItems, ds => ds.id);
     SelectItemsDialog.showModal({
       dialogTitle: i18next.t("Groups:Add Dashboards"),

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -275,7 +275,7 @@ Dashboard.prototype.getUrl = function getUrl() {
 };
 
 const DashboardEndpoints = {
-  query: () => axios.get("api/dashboards"),
+  query: (params = {}) => axios.get("api/dashboards", { params }),
   get: ({ id }) => axios.get(`api/dashboards/${id}`),
 };
 export default DashboardEndpoints;


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

The problem started when we could not add a certain old dashbaord to a group (check the [issue](https://github.com/metr-systems/backlog/issues/3887#event-17416653787) for details).

The reason seems to be because of pagination. When we attempt to add a dashboard to a group, the list of dashboards is returned paginated but was not processed correctly in the old cold.

In this code update we make sure we show dashboards from all the pages.

## How is this tested?

- [x] Manually (locally and deployed on staging )

## Related Tickets & Documents

Closes https://github.com/metr-systems/backlog/issues/3887#event-17416653787

