### PR TITLE
Fix unkown selector

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1027,7 +1027,7 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
             "ALERT_NAME": self.name,
             "ALERT_URL": "{host}/alerts/{alert_id}".format(host=host, alert_id=self.id),
             "ALERT_STATUS": self.state.upper(),
-            "ALERT_SELECTOR": self.options["selector"],
+            "ALERT_SELECTOR": self.options.get("selector", "UNKNOWN"),
             "ALERT_CONDITION": self.options["op"],
             "ALERT_THRESHOLD": self.options["value"],
             "QUERY_NAME": self.query_rel.name,

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -191,6 +191,47 @@ class TestAlertRenderTemplate(BaseTestCase):
         result = alert.render_template(textwrap.dedent(custom_alert))
         self.assertMultiLineEqual(result, textwrap.dedent(expected))
 
+    def test_render_ignore_unknown_selector(self):
+        alert = self.create_alert(get_results(1))
+        alert.options.pop("selector")
+
+        custom_alert = """
+        <pre>
+        ALERT_STATUS        {{ALERT_STATUS}}
+        ALERT_SELECTOR      {{ALERT_SELECTOR}}
+        ALERT_CONDITION     {{ALERT_CONDITION}}
+        ALERT_THRESHOLD     {{ALERT_THRESHOLD}}
+        ALERT_NAME          {{ALERT_NAME}}
+        ALERT_URL           {{{ALERT_URL}}}
+        QUERY_NAME          {{QUERY_NAME}}
+        QUERY_URL           {{{QUERY_URL}}}
+        QUERY_RESULT_VALUE  {{QUERY_RESULT_VALUE}}
+        QUERY_RESULT_ROWS   {{{QUERY_RESULT_ROWS}}}
+        QUERY_RESULT_COLS   {{{QUERY_RESULT_COLS}}}
+        </pre>
+        """
+        expected = """
+        <pre>
+        ALERT_STATUS        UNKNOWN
+        ALERT_SELECTOR      UNKNOWN
+        ALERT_CONDITION     equals
+        ALERT_THRESHOLD     5
+        ALERT_NAME          %s
+        ALERT_URL           https:///default/alerts/%d
+        QUERY_NAME          Query
+        QUERY_URL           https:///default/queries/%d
+        QUERY_RESULT_VALUE  1
+        QUERY_RESULT_ROWS   [{'foo': 1}]
+        QUERY_RESULT_COLS   [{'name': 'foo', 'type': 'STRING'}]
+        </pre>
+        """ % (
+            alert.name,
+            alert.id,
+            alert.query_id,
+        )
+        result = alert.render_template(textwrap.dedent(custom_alert))
+        self.assertMultiLineEqual(result, textwrap.dedent(expected))
+
     def test_render_custom_alert_template_query_table(self):
         alert = self.create_alert(get_results(1))
         custom_alert = """


### PR DESCRIPTION
The selector option was introduced later and some alerts don't have it. This is fixing the case for Alerts with custom templates
