### PR TITLE
Feature/hide filter when non admin

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -15,7 +15,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: restyled-io/actions/setup@v4
+      - name: Setup Restyled with fallback
+        run: |
+          # Try the official setup action first, fall back to manual install if it fails
+          if ! curl -sSfL https://github.com/restyled-io/restyler/releases/download/v0.7.0.0/restyler-linux-x86_64.tar.gz | tar -xz; then
+            echo "Official v0.7.0.0 failed, trying v0.6.0..."
+            curl -sSfL https://github.com/restyled-io/restyler/releases/download/v0.6.0/restyler-linux-x86_64.tar.gz | tar -xz
+          fi
+          sudo cp restyler-*/restyle /usr/local/bin/
+          sudo chmod +x /usr/local/bin/restyle
+
       - id: restyler
         uses: restyled-io/actions/run@v4
         with:

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -15,6 +15,7 @@ import Parameters from "@/components/Parameters";
 import Filters from "@/components/Filters";
 
 import { Dashboard } from "@/services/dashboard";
+import { currentUser } from "@/services/auth";
 import recordEvent from "@/services/recordEvent";
 import resizeObserver from "@/services/resizeObserver";
 import routes from "@/services/routes";
@@ -77,7 +78,7 @@ AddWidgetContainer.propTypes = {
   className: PropTypes.string,
 };
 
-function DashboardComponent(props) {
+export function DashboardComponent(props) {
   const dashboardConfiguration = useDashboard(props.dashboard);
   const {
     dashboard,
@@ -139,7 +140,7 @@ function DashboardComponent(props) {
           />
         }
       />
-      {!isEmpty(globalParameters) && (
+      {!isEmpty(globalParameters) && (currentUser.isAdmin || currentUser.is_default || !!currentUser.apiKey) && (
         <div className="dashboard-parameters m-b-10 p-15 bg-white tiled" data-test="DashboardParameters">
           <Parameters
             parameters={globalParameters}

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -140,7 +140,7 @@ export function DashboardComponent(props) {
           />
         }
       />
-      {!isEmpty(globalParameters) && (currentUser.isAdmin || currentUser.is_default || !!currentUser.apiKey) && (
+      {!isEmpty(globalParameters) && (currentUser.isAdmin || currentUser.is_default) && (
         <div className="dashboard-parameters m-b-10 p-15 bg-white tiled" data-test="DashboardParameters">
           <Parameters
             parameters={globalParameters}

--- a/client/app/pages/dashboards/DashboardPage.test.js
+++ b/client/app/pages/dashboards/DashboardPage.test.js
@@ -15,7 +15,7 @@ describe("DashboardPage Parameter Visibility", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Default mock configuration
     mockUseDashboard.mockReturnValue({
       dashboard: mockDashboard,
@@ -35,7 +35,7 @@ describe("DashboardPage Parameter Visibility", () => {
     });
 
     const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
-    
+
     expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
   });
 
@@ -49,7 +49,7 @@ describe("DashboardPage Parameter Visibility", () => {
     });
 
     const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
-    
+
     expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
   });
 
@@ -63,7 +63,7 @@ describe("DashboardPage Parameter Visibility", () => {
     });
 
     const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
-    
+
     expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(0);
   });
 
@@ -77,7 +77,7 @@ describe("DashboardPage Parameter Visibility", () => {
     });
 
     const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
-    
+
     expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(0);
   });
 });

--- a/client/app/pages/dashboards/DashboardPage.test.js
+++ b/client/app/pages/dashboards/DashboardPage.test.js
@@ -1,0 +1,97 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { DashboardComponent } from "./DashboardPage";
+import * as auth from "@/services/auth";
+
+// Mock dependencies
+jest.mock("@/services/auth");
+jest.mock("./hooks/useDashboard", () => jest.fn());
+
+const mockUseDashboard = require("./hooks/useDashboard");
+
+describe("DashboardPage Parameter Visibility", () => {
+  const mockDashboard = { id: 1 };
+  const mockParameters = [{ name: "region", title: "Region" }];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Default mock configuration
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: [],
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+  });
+
+  it("shows parameters for admin users", () => {
+    auth.currentUser = { isAdmin: true };
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: mockParameters,
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+
+    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
+    
+    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
+  });
+
+  it("shows parameters for default group users", () => {
+    auth.currentUser = { isAdmin: false, is_default: true };
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: mockParameters,
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+
+    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
+    
+    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
+  });
+
+  it("shows parameters for API users (public dashboards)", () => {
+    auth.currentUser = { isAdmin: false, is_default: false, apiKey: "test-key" };
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: mockParameters,
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+
+    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
+    
+    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
+  });
+
+  it("hides parameters for custom group users", () => {
+    auth.currentUser = { isAdmin: false, is_default: false };
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: mockParameters,
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+
+    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
+    
+    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(0);
+  });
+
+  it("does not show parameters when none exist", () => {
+    auth.currentUser = { isAdmin: true };
+    mockUseDashboard.mockReturnValue({
+      dashboard: mockDashboard,
+      globalParameters: [], // No parameters
+      refreshDashboard: jest.fn(),
+      editingLayout: false,
+    });
+
+    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
+    
+    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(0);
+  });
+});

--- a/client/app/pages/dashboards/DashboardPage.test.js
+++ b/client/app/pages/dashboards/DashboardPage.test.js
@@ -53,20 +53,6 @@ describe("DashboardPage Parameter Visibility", () => {
     expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
   });
 
-  it("shows parameters for API users (public dashboards)", () => {
-    auth.currentUser = { isAdmin: false, is_default: false, apiKey: "test-key" };
-    mockUseDashboard.mockReturnValue({
-      dashboard: mockDashboard,
-      globalParameters: mockParameters,
-      refreshDashboard: jest.fn(),
-      editingLayout: false,
-    });
-
-    const wrapper = shallow(<DashboardComponent dashboard={mockDashboard} />);
-    
-    expect(wrapper.find('[data-test="DashboardParameters"]')).toHaveLength(1);
-  });
-
   it("hides parameters for custom group users", () => {
     auth.currentUser = { isAdmin: false, is_default: false };
     mockUseDashboard.mockReturnValue({


### PR DESCRIPTION
### AI Disclaimer: 

I used Github copilot, mainly for the unit tests.

### What type of PR is this? 

- [x] Feature

### Summary
This PR adds a condition to restrict dashboard parameter control/filter visibility to authorized users only aka only users in admin or in default groups. 

### Description / Code Strategy

- Custom users will have access to an overview in which they have urls to dashboards (dashboards they work on), the urls have parameters set.

- When a custom user click on the url, they get redirected to the dashboard , the param is in the url but does not show the control/filter.

- If a custom user clicks on a dashboard link that does not have a parameter set , he won't have anything in the link and the dashboard will not execute any queries because it will be lacking the parameter.

- if a custom user changes the value from the url , the queries will actually run against it , and that is okay in our case since it is not a security problem that we are trying to solve but mainly and overview/UX one.

- :rotating_light: This will impact all users who are not in Admin or Default groups.

- Nothing changes for Admin or default users.

### QA / How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually on staging


### Related Tickets & Documents

Closes [github.com/metr-systems/repo/issues/99999](https://github.com/metr-systems/backlog/issues/3874)

[Link to the Gemini summary of the refinement , notice that it includes more topics](https://docs.google.com/document/d/1_2_4dZ5cMpmkQs4mIdLniN95o8bzmfxt4lz8PHxaq-4/edit?tab=t.hh95fhspsp7k)

### Mobile & Desktop Screenshots/Recordings (if there are UI changes)

For admin user 

<img width="1189" height="536" alt="Screenshot 2025-12-11 at 15 21 50" src="https://github.com/user-attachments/assets/ab819f04-a80a-41a7-8264-ec19451c2931" />

For custom user 

<img width="1187" height="455" alt="Screenshot 2025-12-11 at 15 22 23" src="https://github.com/user-attachments/assets/772aa37a-8411-4edc-b676-f38dd6d6d138" />

@helenalebreton  let me know and we can also test it again together on staging 