### PR TITLE
improve multi-platform build and frontend performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:18-bookworm AS frontend-builder
+# Enable native platform builds for frontend (faster on ARM Macs)
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+FROM --platform=$BUILDPLATFORM node:18-bookworm AS frontend-builder
 
 RUN npm install --global --force yarn@1.22.22
 
@@ -15,15 +18,15 @@ WORKDIR /frontend
 COPY --chown=redash package.json yarn.lock .yarnrc /frontend/
 COPY --chown=redash viz-lib /frontend/viz-lib
 COPY --chown=redash scripts /frontend/scripts
-
 # Controls whether to instrument code for coverage information
 ARG code_coverage
 ENV BABEL_ENV=${code_coverage:+test}
 
-# Avoid issues caused by lags in disk and network I/O speeds when working on top of QEMU emulation for multi-platform image building.
+# Increase timeout for slower connections
 RUN yarn config set network-timeout 300000
+# Now building on native platform, so we can use parallel downloads
 
-RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn --frozen-lockfile --network-concurrency 1; fi
+RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn --frozen-lockfile; fi
 
 COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
@@ -73,7 +76,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 
-ARG TARGETPLATFORM
+
 ARG databricks_odbc_driver_url=https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.6.26/SimbaSparkODBC-2.6.26.1045-Debian-64bit.zip
 RUN <<EOF
   if [ "$TARGETPLATFORM" = "linux/amd64" ]; then

--- a/publish_docker_images.sh
+++ b/publish_docker_images.sh
@@ -64,7 +64,7 @@ fi
 
 set -e
 
-docker build $DOCKER_CACHE_FLAG --build-arg install_groups="main,metr" --platform linux/amd64 -t redash-metr .
+docker buildx build $DOCKER_CACHE_FLAG --build-arg install_groups="main,metr" --platform linux/amd64 -t redash-metr .
 
 
 function tag_and_push_image() {


### PR DESCRIPTION
## AI Disclaimer: 
Gemini was used

## What type of PR is this? 

- [x] Refactor


## Summary / Code Strategy

This PR refactors the Dockerfile to enhance multi-platform build support and improve frontend build performance. By leveraging native platform builds and optimizing Yarn configuration, the changes streamline the build process, particularly for ARM-based and multi-architecture environments. 

## Description

- Add `BUILDPLATFORM` and `TARGETPLATFORM` build arguments and use` --platform=$BUILDPLATFORM` for the frontend builder stage
to enable native platform builds (improves speed, especially on ARM Macs).
- Remove `--network-concurrency 1` from Yarn install, allowing parallel downloads now that native builds are used.
- Minor cleanup and reordering for clarity.

These changes improve build reliability and performance, especially for ARM-based development environments and multi-platform Docker builds.

## QA/ How is this tested?
- [x] Manually

## :rotating_light: Call to action 

This works great on MAC M1 but we need to test this on other machines because we merge it. would be great if you can check it  by running `./publish_docker_images.sh -t develop` and tell us if it does not take much time. It should not take more than few minutes.

## Related Tickets & Documents
closes https://github.com/metr-systems/backlog/issues/4395#issuecomment-3607211272

