### PR TITLE
add loading spinner to the dashboard page

### DIFF
--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -15,6 +15,7 @@ import Parameters from "@/components/Parameters";
 import Filters from "@/components/Filters";
 import FixedParameters from "@/components/FixedParameters";
 import BackButton from "@/components/backButton";
+import BigMessage from "@/components/BigMessage";
 
 import { Dashboard } from "@/services/dashboard";
 import recordEvent from "@/services/recordEvent";
@@ -205,9 +206,12 @@ DashboardComponent.propTypes = {
 
 function DashboardPage({ dashboardSlug, dashboardId, onError }) {
   const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(true);
   const handleError = useImmutableCallback(onError);
+  const { t } = useTranslation();
 
   useEffect(() => {
+    setLoading(true);
     Dashboard.get({ id: dashboardId, slug: dashboardSlug })
       .then((dashboardData) => {
         recordEvent("view", "dashboard", dashboardData.id);
@@ -218,10 +222,21 @@ function DashboardPage({ dashboardSlug, dashboardId, onError }) {
           location.setPath(url.parse(dashboardData.url).pathname, true);
         }
       })
-      .catch(handleError);
+      .catch(handleError)
+      .finally(() => setLoading(false));
   }, [dashboardId, dashboardSlug, handleError]);
 
-  return <div className="dashboard-page">{dashboard && <DashboardComponent dashboard={dashboard} />}</div>;
+  return (
+    <div className="dashboard-page">
+      {loading ? (
+        <div className="container text-center p-t-10">
+          <BigMessage icon="fa-spinner fa-2x fa-pulse" message={t("Loading...")} />
+        </div>
+      ) : (
+        dashboard && <DashboardComponent dashboard={dashboard} />
+      )}
+    </div>
+  );
 }
 
 DashboardPage.propTypes = {


### PR DESCRIPTION
closes https://github.com/metr-systems/backlog/issues/4317
AI disclaimer : I used AI in this PR to generate the code and then i reviewed it piece by piece

## What type of PR is this? 

- [x] Feature

## Summary

In this PR we add a loading spinner to the dashboard page. The spinner is be displayed for the duration of the API call to fetch dashboard data, providing immediate feedback to users instead of the confusing blank gray screen that shows especially when the dashboard has a lot of widgets.

## Code Strategy

**Consistent UI**: Uses the same BigMessage component with fa-spinner fa-2x fa-pulse icon that's used throughout the application
**Proper timing**: Loading state starts immediately when component mounts and clears when data is fetched (or on error)
**Proper styling**

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWE2N21meTRtbG42YjBqM3hsMnFrcG9uc3N4b2szNjgxcmVyb2tvYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/yJHN2CCfPIw4o/giphy.gif)

## QA

- [x] Manually
it is deployed on staging , hard to catch for a picture hehe , but you can see it for a short moment when accessing this for example https://dashboard.staging.metr.systems/staging/dashboards?order=-created_at&page=1&page_size=20
