### PR TITLE
update pr template to be conform with metr templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,33 @@
-## What type of PR is this? 
+Closes github.com/metr-systems/repo/issues/99999
+
+Link to the Gemini summary of the refinement, if there was one](https://example.com)
+
+AI Disclaimer: Did you use AI? How?
+
+# What type of PR is this?
+
 <!-- Check all that apply, delete what doesn't apply. -->
 
 - [ ] Refactor
 - [ ] Feature
 - [ ] Bug Fix
-- [ ] New Query Runner (Data Source) 
+- [ ] New Query Runner (Data Source)
 - [ ] New Alert Destination
 - [ ] Other
 
-## Description
-<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
+# Summary
 
-## How is this tested?
+What did you do, and what problem does this solve? Keep in mind the SE team.
+
+# Code Strategy
+
+Why did you do what you did? Keep the other developers in mind.
+
+# QA
+
+How did you test it? Keep your future self in mind to help debug things later.
 
 - [ ] Unit tests (pytest, jest)
 - [ ] E2E Tests (Cypress)
 - [ ] Manually
 - [ ] N/A
-
-<!-- If Manually, please describe. -->
-
-## Related Tickets & Documents
-<!-- If applicable, please include a link to your documentation PR against getredash/website -->
-
-## Mobile & Desktop Screenshots/Recordings (if there are UI changes)


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4557

AI Disclaimer: x

# What type of PR is this? 

- [x] Refactor

# Summary
I modify the original PR template to be consistent with our templates at metr ([core-backend example](https://github.com/metr-systems/core-backend/blob/develop/.github/pull_request_template.md)). I kept few details like the type of PR and the types of tests to tick because i like them , but let me know what you think about that.

# QA 

will see once merged hehe, but there is no reason it won't work

