### PR TITLE
preserve schedule when forking queries

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -754,12 +754,11 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         forked_list = [
             "org",
             "data_source",
-            "latest_query_data",
             "description",
             "query_text",
-            "query_hash",
             "options",
             "tags",
+            "schedule",
         ]
         kwargs = {a: getattr(self, a) for a in forked_list}
 

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -464,7 +464,7 @@ class TestQueryFork(BaseTestCase):
 
         forked_query = query.fork(self.factory.user)
 
-        self.assertEqual(query.schedule, forked_query.schedule)
+        self.assertDictEqual(query.schedule, forked_query.schedule)
         self.assertEqual(forked_query.schedule["interval"], 3600)
 
 

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -458,6 +458,15 @@ class TestQueryFork(BaseTestCase):
 
         self.assertEqual(query.tags, forked_query.tags)
 
+    def test_fork_keeps_query_schedule(self):
+        schedule = {"interval": 3600, "until": None, "time": None, "day_of_week": None}
+        query = self.factory.create_query(schedule=schedule)
+
+        forked_query = query.fork(self.factory.user)
+
+        self.assertEqual(query.schedule, forked_query.schedule)
+        self.assertEqual(forked_query.schedule["interval"], 3600)
+
 
 class TestQueryUpdateLatestResult(BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/3609

AI disclaimer: used claude with the test 

# Summary

When forking scheduled queries in Redash, the schedule configuration was not being copied to the forked query, requiring users to manually recreate scheduling from scratch.

The `Query.fork()` method did not include `schedule` in the list of attributes to copy from the original query.

In this PR we update forking queries to **preserve schedule** and also to **start with fresh execution context**

# Code Strategy

We enhanced `Query.fork()` to include `schedule`  to preserve scheduling configuration. We also enhance it by removing `latest_query_data` and `query_hash`, please find the explanation for it in the following paragraph.

Forked queries are typically manually modified and re-executed immediately, so starting with fresh execution context is optimal. `latest_query_data` and `query_hash` are intentionally omitted, ensuring forked queries start with clean execution state. This is safe because a fresh `query_hash` is automatically generated via the existing `@listens_for(Query, "before_insert") `event handler. 

This ensures forked queries preserve their scheduling configuration while starting with a clean execution state, eliminating manual schedule recreation workflows which can easily be forgotten.

------------------------
Do you want to know more about `latest_query_data` and `query_hash`? then maybe you need to read the following , otherwise you can skip:

When a query is executed, the result is  a `QueryResult` and is saved in the `latest_query_data` of the `query`.

Both the query and the query result do have each its `query_hash` that is calculated at different moments: 
  - The query gets its `query_hash` calculated when its text (with params calculated) is being [created or updated](https://github.com/metr-systems/redash/blob/620f6591c1223c1db3651830a8d4a674035bd74c/redash/models/__init__.py#L847). 
  - For the query result , it gets calculated when the query is actually executed. [[link1](https://github.com/metr-systems/redash/blob/620f6591c1223c1db3651830a8d4a674035bd74c/redash/models/__init__.py#L348) , [link2](https://github.com/metr-systems/redash/blob/620f6591c1223c1db3651830a8d4a674035bd74c/redash/handlers/query_results.py#L89)]
  
Then these two `query_hash` are [compared](https://github.com/metr-systems/redash/blob/620f6591c1223c1db3651830a8d4a674035bd74c/redash/handlers/query_results.py#L332) at the API level for getting cached data if possible 

This is why actually only removing `latest_query_data` did not work at the begining because anyway we were getting the cached data using the `query_hash`

# QA

- [x] Unit tests (pytest, jest)
- [x] Manually (deployed on staging)
