### PR TITLE
Feature/add url identifier routing

### DIFF
--- a/client/app/components/dashboards/UrlIdentifierContainer.jsx
+++ b/client/app/components/dashboards/UrlIdentifierContainer.jsx
@@ -57,6 +57,9 @@ function UrlIdentifierContainer({ dashboardConfiguration, style }) {
   // Display the shareable URL when identifier exists
   if (dashboard.url_identifier || justUpdatedIdentifier) {
     const displayUrlIdentifier = dashboard.url_identifier || justUpdatedIdentifier;
+    const basePath = window.location.pathname.split('/dashboards')[0];
+    const urlPath = `${basePath}/dashboards/by_url_identifier/${displayUrlIdentifier}`;
+    
     return (
       <div className="add-widget-container url-identifier-container" style={style}>
         <h2>
@@ -64,7 +67,7 @@ function UrlIdentifierContainer({ dashboardConfiguration, style }) {
           <span className="hidden-xs hidden-sm">{t("This dashboard has a URL identifier")}.</span>
         </h2>
         <InputWithCopy
-          value={`${window.location.origin}/dashboards/by_url_identifier/${displayUrlIdentifier}`}
+          value={`${window.location.origin}${urlPath}`}
           readOnly
           className="url-identifier-input"
         />

--- a/client/app/components/dashboards/UrlIdentifierContainer.jsx
+++ b/client/app/components/dashboards/UrlIdentifierContainer.jsx
@@ -57,20 +57,16 @@ function UrlIdentifierContainer({ dashboardConfiguration, style }) {
   // Display the shareable URL when identifier exists
   if (dashboard.url_identifier || justUpdatedIdentifier) {
     const displayUrlIdentifier = dashboard.url_identifier || justUpdatedIdentifier;
-    const basePath = window.location.pathname.split('/dashboards')[0];
+    const basePath = window.location.pathname.split("/dashboards")[0];
     const urlPath = `${basePath}/dashboards/by_url_identifier/${displayUrlIdentifier}`;
-    
+
     return (
       <div className="add-widget-container url-identifier-container" style={style}>
         <h2>
           <i className="zmdi zmdi-widgets" aria-hidden="true" />
           <span className="hidden-xs hidden-sm">{t("This dashboard has a URL identifier")}.</span>
         </h2>
-        <InputWithCopy
-          value={`${window.location.origin}${urlPath}`}
-          readOnly
-          className="url-identifier-input"
-        />
+        <InputWithCopy value={`${window.location.origin}${urlPath}`} readOnly className="url-identifier-input" />
       </div>
     );
   }

--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -1,11 +1,14 @@
-from flask import render_template, send_file
-from flask_login import login_required
+from flask import redirect, render_template, send_file
+from flask_login import current_user, login_required
+from werkzeug.exceptions import NotFound
 from werkzeug.utils import safe_join
 
-from redash import settings
+from redash import models, settings
+from redash.authentication.org_resolving import current_org
 from redash.handlers import routes
 from redash.handlers.authentication import base_href
 from redash.handlers.base import org_scoped_rule
+from redash.permissions import require_dashboard_group_access
 from redash.security import csp_allows_embeding
 
 
@@ -24,6 +27,24 @@ def render_index():
 @csp_allows_embeding
 def dashboard(slug, org_slug=None):
     return render_index()
+
+
+@routes.route(org_scoped_rule("/dashboards/by_url_identifier/<url_identifier>"), methods=["GET"])
+@login_required
+@csp_allows_embeding
+def dashboard_by_url_identifier(url_identifier, org_slug):
+    try:
+        current_org_obj = current_org._get_current_object()
+        dashboard = models.Dashboard.get_by_url_identifier_and_org(url_identifier, current_org_obj)
+        require_dashboard_group_access(dashboard, current_user)
+
+        # Redirect to canonical dashboard URL with org prefix
+        canonical_path = f"/{org_slug}/dashboards/{dashboard.id}-{dashboard.slug}"
+
+        return redirect(canonical_path, code=302)
+
+    except Exception:
+        raise NotFound()
 
 
 @routes.route(org_scoped_rule("/<path:path>"))

--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -1,6 +1,5 @@
 from flask import redirect, render_template, send_file
-from flask_login import current_user, login_required
-from werkzeug.exceptions import NotFound
+from flask_login import login_required
 from werkzeug.utils import safe_join
 
 from redash import models, settings
@@ -8,7 +7,6 @@ from redash.authentication.org_resolving import current_org
 from redash.handlers import routes
 from redash.handlers.authentication import base_href
 from redash.handlers.base import org_scoped_rule
-from redash.permissions import require_dashboard_group_access
 from redash.security import csp_allows_embeding
 
 
@@ -33,18 +31,13 @@ def dashboard(slug, org_slug=None):
 @login_required
 @csp_allows_embeding
 def dashboard_by_url_identifier(url_identifier, org_slug):
-    try:
-        current_org_obj = current_org._get_current_object()
-        dashboard = models.Dashboard.get_by_url_identifier_and_org(url_identifier, current_org_obj)
-        require_dashboard_group_access(dashboard, current_user)
+    current_org_obj = current_org._get_current_object()
+    dashboard = models.Dashboard.get_by_url_identifier_and_org_or_404(url_identifier, current_org_obj)
 
-        # Redirect to canonical dashboard URL with org prefix
-        canonical_path = f"/{org_slug}/dashboards/{dashboard.id}-{dashboard.slug}"
+    # Redirect to canonical dashboard URL with org prefix
+    canonical_path = f"/{org_slug}/dashboards/{dashboard.id}-{dashboard.slug}"
 
-        return redirect(canonical_path, code=302)
-
-    except Exception:
-        raise NotFound()
+    return redirect(canonical_path, code=302)
 
 
 @routes.route(org_scoped_rule("/<path:path>"))

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -21,6 +21,7 @@ from sqlalchemy_utils import generic_relationship
 from sqlalchemy_utils.models import generic_repr
 from sqlalchemy_utils.types import TSVectorType
 from sqlalchemy_utils.types.encrypted.encrypted_type import FernetEngine
+from werkzeug.exceptions import NotFound
 
 from redash import redis_connection, settings, utils
 from redash.destinations import (
@@ -1188,13 +1189,16 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
         return cls.query.filter(cls.slug == slug, cls.org == org).one()
 
     @classmethod
-    def get_by_url_identifier_and_org(cls, url_identifier, org):
-        """Get dashboard by URL identifier and organization."""
-        return (
+    def get_by_url_identifier_and_org_or_404(cls, url_identifier, org):
+        """Get dashboard by URL identifier and organization, or raise 404."""
+        dashboard = (
             cls.query.join(MetrDashboard, cls.id == MetrDashboard.dashboard_id)
             .filter(MetrDashboard.url_identifier == url_identifier, MetrDashboard.org_id == org.id)
-            .one()
+            .first()
         )
+        if not dashboard:
+            raise NotFound()
+        return dashboard
 
     def fork(self, user):
         forked_list = ["org", "layout", "dashboard_filters_enabled", "tags"]

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1187,6 +1187,15 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
     def get_by_slug_and_org(cls, slug, org):
         return cls.query.filter(cls.slug == slug, cls.org == org).one()
 
+    @classmethod
+    def get_by_url_identifier_and_org(cls, url_identifier, org):
+        """Get dashboard by URL identifier and organization."""
+        return (
+            cls.query.join(MetrDashboard, cls.id == MetrDashboard.dashboard_id)
+            .filter(MetrDashboard.url_identifier == url_identifier, MetrDashboard.org_id == org.id)
+            .one()
+        )
+
     def fork(self, user):
         forked_list = ["org", "layout", "dashboard_filters_enabled", "tags"]
 

--- a/tests/handlers/test_static.py
+++ b/tests/handlers/test_static.py
@@ -1,0 +1,45 @@
+from redash.models import MetrDashboard, db
+from tests import BaseTestCase
+
+
+class TestDashboardByUrlIdentifier(BaseTestCase):
+    def test_successful_redirect(self):
+        dashboard = self.factory.create_dashboard()
+        group = self.factory.create_group()
+
+        # Create a user with proper group access
+        test_user = self.factory.create_user()
+        test_user.group_ids = [group.id]
+
+        metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="test-id")
+        db.session.add(metr_dashboard)
+        self.factory.create_dashboard_group_permission(dashboard, group)
+        db.session.commit()
+
+        rv = self.make_request("get", "/dashboards/by_url_identifier/test-id", user=test_user, is_json=False)
+
+        self.assertEqual(rv.status_code, 302)
+        expected_path = f"/{self.factory.org.slug}/dashboards/{dashboard.id}-{dashboard.slug}"
+        self.assertEqual(rv.location, expected_path)
+
+    def test_not_found(self):
+        # Create a user for authentication
+        test_user = self.factory.create_user()
+
+        rv = self.make_request("get", "/dashboards/by_url_identifier/nonexistent", user=test_user, is_json=False)
+
+        self.assertEqual(rv.status_code, 404)
+
+    def test_access_denied(self):
+        dashboard = self.factory.create_dashboard()
+
+        # Create a user without dashboard access
+        test_user = self.factory.create_user()
+
+        metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="private-id")
+        db.session.add(metr_dashboard)
+        db.session.commit()
+
+        rv = self.make_request("get", "/dashboards/by_url_identifier/private-id", user=test_user, is_json=False)
+
+        self.assertEqual(rv.status_code, 404)

--- a/tests/handlers/test_static.py
+++ b/tests/handlers/test_static.py
@@ -5,15 +5,12 @@ from tests import BaseTestCase
 class TestDashboardByUrlIdentifier(BaseTestCase):
     def test_successful_redirect(self):
         dashboard = self.factory.create_dashboard()
-        group = self.factory.create_group()
 
-        # Create a user with proper group access
+        # Create a user for authentication
         test_user = self.factory.create_user()
-        test_user.group_ids = [group.id]
 
         metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="test-id")
         db.session.add(metr_dashboard)
-        self.factory.create_dashboard_group_permission(dashboard, group)
         db.session.commit()
 
         rv = self.make_request("get", "/dashboards/by_url_identifier/test-id", user=test_user, is_json=False)
@@ -27,19 +24,5 @@ class TestDashboardByUrlIdentifier(BaseTestCase):
         test_user = self.factory.create_user()
 
         rv = self.make_request("get", "/dashboards/by_url_identifier/nonexistent", user=test_user, is_json=False)
-
-        self.assertEqual(rv.status_code, 404)
-
-    def test_access_denied(self):
-        dashboard = self.factory.create_dashboard()
-
-        # Create a user without dashboard access
-        test_user = self.factory.create_user()
-
-        metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="private-id")
-        db.session.add(metr_dashboard)
-        db.session.commit()
-
-        rv = self.make_request("get", "/dashboards/by_url_identifier/private-id", user=test_user, is_json=False)
 
         self.assertEqual(rv.status_code, 404)


### PR DESCRIPTION
Closes https://github.com/orgs/metr-systems/projects/16?pane=issue&itemId=156558975&issue=metr-systems%7Cbacklog%7C4602

AI Disclaimer: Yes , i did use it mainly with tests

# Summary

This PR closes the url identifier topic. It gives us the opportunity to be redirected to the dashboard we aim for, starting from a link that uses the url identifier. 

For example : from https://dashboard.staging.metr.systems/staging/dashboards/by_url_identifier/sdasdasda you get redirected to https://dashboard.staging.metr.systems/staging/dashboards/71-test-t12

# Code Strategy

We initially follow the code used for getting a dashboard by slug , so we add `dashboard_by_url_identifier` in statics file, later inside this function we make sure everything is handled there (on the backend side) we do nothing from frontend and we don't touch ressources.

A fix is added to the url identifier container in order to show the correct link that we can copy from the dashboard edit page and use directly.

Exception handling in `dashboard_by_url_identifier` is generic, in purpose. If the dashboard exists and is accessible we redirect to it otherwise we show 404, just to make things simple because anyway these cases are not supposed to happen. What do you think please?

# QA

unit tests + on staging (you can test it there)