### PR TITLE
include Dashboard Editing Architecture design record

### DIFF
--- a/metr_docs/design_records/dashboard_editing_architecture.md
+++ b/metr_docs/design_records/dashboard_editing_architecture.md
@@ -1,0 +1,13 @@
+# Design Record: Dashboard Editing Architecture
+
+## Context
+
+Redash has an editing interface that allows users to modify dashboard properties, add widgets, rearrange layouts. The editing experience needs to be responsive and provide immediate feedback while ensuring data persistence and consistency.
+
+---
+
+## Decision
+
+Dashboard editing follows a **direct persistence model** where each modification is immediately saved to the backend via individual API calls, rather than using a traditional form-based submission approach. We decide to follow this decision for our metr changes.
+
+


### PR DESCRIPTION

# Summary

This is just a documentation as follow up to our recent work on making the url identifier able to be set from the page in which we edit dashboards.

I will need to merge after a moment since i need to deploy and I wanted to include with the related work.