### PR TITLE
Poc/global redash

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,4 @@
 REDASH_COOKIE_SECRET=
 REDASH_SECRET_KEY=
 DATABASE_URL=postgres://postgres:@localhost/db_name
+REDASH_GLOBAL_API_TOKEN=your-secret-token-here

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -49,6 +49,14 @@ server() {
   exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
 }
 
+global_server() {
+  # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
+  MAX_REQUESTS=${MAX_REQUESTS:-1000}
+  MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
+  TIMEOUT=${REDASH_GUNICORN_TIMEOUT:-60}
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5001 --name redash-global -w${REDASH_GLOBAL_WEB_WORKERS:-2} redash_global.wsgi_global:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
+}
+
 create_db() {
   exec /app/manage.py database create_tables
 }
@@ -60,6 +68,7 @@ help() {
   echo ""
 
   echo "server -- start Redash server (with gunicorn)"
+  echo "global_server -- start Redash Global server (with gunicorn)"
   echo "worker -- start a single RQ worker"
   echo "dev_worker -- start a single RQ worker with code reloading"
   echo "scheduler -- start an rq-scheduler instance"
@@ -96,6 +105,10 @@ case "$1" in
   server)
     shift
     server
+    ;;
+  global_server)
+    shift
+    global_server
     ;;
   scheduler)
     shift

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -42,7 +42,7 @@ dev_worker() {
 }
 
 server() {
-  # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
+  # Recycle gunicorn workers every n-th request. See https://gunicorn.org/reference/settings/#max_requests for more details.
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
   TIMEOUT=${REDASH_GUNICORN_TIMEOUT:-60}
@@ -50,7 +50,7 @@ server() {
 }
 
 global_server() {
-  # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
+  # Recycle gunicorn workers every n-th request. See https://gunicorn.org/reference/settings/#max-requests for more details.
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
   TIMEOUT=${REDASH_GUNICORN_TIMEOUT:-60}

--- a/redash_global/__init__.py
+++ b/redash_global/__init__.py
@@ -1,0 +1,1 @@
+"""Redash Global - Cross-organization operations service"""

--- a/redash_global/app.py
+++ b/redash_global/app.py
@@ -1,0 +1,27 @@
+"""Flask application factory for Redash Global service."""
+
+from flask import Flask
+
+# Import models to ensure they are registered with SQLAlchemy
+# Import Redash database and models
+from redash import settings
+from redash.models.base import db
+
+
+def create_global_app():
+    """Create and configure the Redash Global Flask application."""
+    app = Flask(__name__)
+
+    # Essential database configuration (reuse Redash settings)
+    app.config["SQLALCHEMY_DATABASE_URI"] = settings.SQLALCHEMY_DATABASE_URI
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    # Initialize database with the app
+    db.init_app(app)
+
+    # Import and register routes
+    from redash_global.routes import api_blueprint
+
+    app.register_blueprint(api_blueprint)
+
+    return app

--- a/redash_global/app.py
+++ b/redash_global/app.py
@@ -1,5 +1,7 @@
 """Flask application factory for Redash Global service."""
 
+import os
+
 from flask import Flask
 
 # Import models to ensure they are registered with SQLAlchemy
@@ -8,8 +10,22 @@ from redash import settings
 from redash.models.base import db
 
 
+def _validate_required_config():
+    """Validate required environment variables at startup."""
+    required_env_vars = {"REDASH_GLOBAL_API_TOKEN": "Global API token for authentication"}
+
+    for var_name, description in required_env_vars.items():
+        if not os.environ.get(var_name):
+            raise RuntimeError(
+                f"Required environment variable '{var_name}' is not set. "
+                f"This variable is needed for: {description}"
+            )
+
+
 def create_global_app():
     """Create and configure the Redash Global Flask application."""
+    _validate_required_config()
+
     app = Flask(__name__)
 
     # Essential database configuration (reuse Redash settings)

--- a/redash_global/auth.py
+++ b/redash_global/auth.py
@@ -1,0 +1,35 @@
+"""Authentication module for Redash Global service."""
+
+import os
+from functools import wraps
+
+from flask import jsonify, request
+
+
+def require_global_token(f):
+    """Decorator to require global API token authentication.
+
+    Checks for X-Global-Api-Token header and validates against
+    REDASH_GLOBAL_API_TOKEN environment variable.
+
+    Returns 403 if token is missing or invalid.
+    """
+
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        expected_token = os.environ.get("REDASH_GLOBAL_API_TOKEN")
+
+        if not expected_token:
+            return jsonify({"error": "Global API token not configured"}), 500
+
+        provided_token = request.headers.get("X-Global-Api-Token")
+
+        if not provided_token:
+            return jsonify({"error": "Missing X-Global-Api-Token header"}), 403
+
+        if provided_token != expected_token:
+            return jsonify({"error": "Invalid global API token"}), 403
+
+        return f(*args, **kwargs)
+
+    return decorated_function

--- a/redash_global/auth.py
+++ b/redash_global/auth.py
@@ -23,7 +23,7 @@ def require_global_token(f):
         provided_token = request.headers.get("X-Global-Api-Token")
 
         if not provided_token:
-            return jsonify({"error": "Missing X-Global-Api-Token header"}), 403
+            return jsonify({"error": "Missing X-Global-Api-Token header"}), 401
 
         if provided_token != expected_token:
             return jsonify({"error": "Invalid global API token"}), 403

--- a/redash_global/auth.py
+++ b/redash_global/auth.py
@@ -17,10 +17,8 @@ def require_global_token(f):
 
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        expected_token = os.environ.get("REDASH_GLOBAL_API_TOKEN")
-
-        if not expected_token:
-            return jsonify({"error": "Global API token not configured"}), 500
+        # Token existence is guaranteed before app creation
+        expected_token = os.environ["REDASH_GLOBAL_API_TOKEN"]
 
         provided_token = request.headers.get("X-Global-Api-Token")
 

--- a/redash_global/routes.py
+++ b/redash_global/routes.py
@@ -1,0 +1,65 @@
+"""API routes for Redash Global service."""
+
+from flask import Blueprint, jsonify, request
+
+from redash_global.auth import require_global_token
+from redash_global.services.organizations import (
+    OrganizationValidationError,
+    create_organization_with_admin,
+)
+
+# Create API blueprint
+api_blueprint = Blueprint("api", __name__, url_prefix="/global-api")
+
+
+@api_blueprint.route("/organizations", methods=["POST"])
+@require_global_token
+def create_organization():
+    """Create a new organization with admin user and built-in groups.
+
+    Expected JSON body:
+    {
+        "name": "Organization Name",
+        "slug": "org-slug",
+        "admin_email": "admin@example.com",
+        "admin_name": "Admin User",
+        "password": "password123"
+    }
+
+    Returns:
+        201: Organization created successfully
+        400: Validation error
+        500: Server error
+    """
+    try:
+        data = request.get_json()
+
+        if not data:
+            return jsonify({"error": "JSON body is required"}), 400
+
+        # Extract required fields
+        required_fields = ["name", "slug", "admin_email", "admin_name", "password"]
+        for field in required_fields:
+            if field not in data:
+                return jsonify({"error": f"Missing required field: {field}"}), 400
+
+        # Create organization
+        result = create_organization_with_admin(
+            name=data["name"],
+            slug=data["slug"],
+            admin_email=data["admin_email"],
+            admin_name=data["admin_name"],
+            password=data["password"],
+        )
+
+        return jsonify(result), 201
+
+    except OrganizationValidationError as e:
+        return jsonify({"error": str(e)}), 400
+
+    except Exception as e:
+        # Log the error for debugging
+        import logging
+
+        logging.error(f"Error creating organization: {e}", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500

--- a/redash_global/routes.py
+++ b/redash_global/routes.py
@@ -1,65 +1,13 @@
 """API routes for Redash Global service."""
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint
 
-from redash_global.auth import require_global_token
-from redash_global.services.organizations import (
-    OrganizationValidationError,
-    create_organization_with_admin,
-)
+from redash_global.views import create_organization_view
 
 # Create API blueprint
 api_blueprint = Blueprint("api", __name__, url_prefix="/global-api")
 
-
-@api_blueprint.route("/organizations", methods=["POST"])
-@require_global_token
-def create_organization():
-    """Create a new organization with admin user and built-in groups.
-
-    Expected JSON body:
-    {
-        "name": "Organization Name",
-        "slug": "org-slug",
-        "admin_email": "admin@example.com",
-        "admin_name": "Admin User",
-        "password": "password123"
-    }
-
-    Returns:
-        201: Organization created successfully
-        400: Validation error
-        500: Server error
-    """
-    try:
-        data = request.get_json()
-
-        if not data:
-            return jsonify({"error": "JSON body is required"}), 400
-
-        # Extract required fields
-        required_fields = ["name", "slug", "admin_email", "admin_name", "password"]
-        for field in required_fields:
-            if field not in data:
-                return jsonify({"error": f"Missing required field: {field}"}), 400
-
-        # Create organization
-        result = create_organization_with_admin(
-            name=data["name"],
-            slug=data["slug"],
-            admin_email=data["admin_email"],
-            admin_name=data["admin_name"],
-            password=data["password"],
-        )
-
-        return jsonify(result), 201
-
-    except OrganizationValidationError as e:
-        return jsonify({"error": str(e)}), 400
-
-    except Exception as e:
-        # Log the error for debugging
-        import logging
-
-        logging.error(f"Error creating organization: {e}", exc_info=True)
-        return jsonify({"error": "Internal server error"}), 500
+# Register routes
+api_blueprint.add_url_rule(
+    "/organizations", methods=["POST"], view_func=create_organization_view, endpoint="create_organization"
+)

--- a/redash_global/services/__init__.py
+++ b/redash_global/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services for cross-organization operations"""

--- a/redash_global/services/organizations.py
+++ b/redash_global/services/organizations.py
@@ -1,0 +1,94 @@
+"""Organization service for Redash Global."""
+
+from redash.models import Group, Organization, User, db
+
+
+class OrganizationValidationError(Exception):
+    """Raised when organization creation validation fails."""
+
+    pass
+
+
+def create_organization_with_admin(name, slug, admin_email, admin_name, password):
+    """Create a new organization with admin user and built-in groups.
+
+    Args:
+        name (str): Organization name
+        slug (str): Organization slug (must be unique)
+        admin_email (str): Email for the first admin user
+        admin_name (str): Name for the first admin user
+        password (str): Password for admin user
+
+    Returns:
+        dict: Structure containing organization and admin user info
+
+    Raises:
+        OrganizationValidationError: If validation fails
+    """
+    # Check if organization slug already exists
+    existing_org = Organization.query.filter(Organization.slug == slug).first()
+    if existing_org:
+        raise OrganizationValidationError(f"Organization with slug '{slug}' already exists")
+
+    # Create organization and groups in a single transaction
+    try:
+        # Create organization
+        org = Organization(name=name, slug=slug, settings={})
+        db.session.add(org)
+        db.session.flush()  # Flush to get the org.id
+
+        # Create admin group
+        admin_group = Group(
+            name="admin",
+            permissions=Group.ADMIN_PERMISSIONS,
+            org=org,
+            type=Group.BUILTIN_GROUP,
+        )
+
+        # Create default group
+        default_group = Group(
+            name="default",
+            permissions=Group.DEFAULT_PERMISSIONS,
+            org=org,
+            type=Group.BUILTIN_GROUP,
+        )
+
+        db.session.add_all([admin_group, default_group])
+        db.session.flush()  # Flush to get group IDs
+
+        # Create admin user
+        admin_user = User(
+            org=org,
+            email=admin_email.lower(),
+            name=admin_name,
+            group_ids=[admin_group.id, default_group.id],
+        )
+
+        # Set password
+        admin_user.hash_password(password)
+
+        db.session.add(admin_user)
+        db.session.flush()  # Flush to get user ID
+
+        # Commit the transaction
+        db.session.commit()
+
+        # Prepare response
+        result = {
+            "organization": {
+                "id": org.id,
+                "name": org.name,
+                "slug": org.slug,
+            },
+            "admin_user": {
+                "id": admin_user.id,
+                "email": admin_user.email,
+                "name": admin_user.name,
+            },
+        }
+
+        return result
+
+    except Exception:
+        db.session.rollback()
+        raise

--- a/redash_global/views.py
+++ b/redash_global/views.py
@@ -1,0 +1,61 @@
+"""View functions for Redash Global service."""
+
+from flask import jsonify, request
+
+from redash_global.auth import require_global_token
+from redash_global.services.organizations import (
+    OrganizationValidationError,
+    create_organization_with_admin,
+)
+
+
+@require_global_token
+def create_organization_view():
+    """Create a new organization with admin user and built-in groups.
+
+    Expected JSON body:
+    {
+        "name": "Organization Name",
+        "slug": "org-slug",
+        "admin_email": "admin@example.com",
+        "admin_name": "Admin User",
+        "password": "password123"
+    }
+
+    Returns:
+        201: Organization created successfully
+        400: Validation error
+        500: Server error
+    """
+    try:
+        data = request.get_json()
+
+        if not data:
+            return jsonify({"error": "JSON body is required"}), 400
+
+        # Extract required fields
+        required_fields = ["name", "slug", "admin_email", "admin_name", "password"]
+        for field in required_fields:
+            if field not in data:
+                return jsonify({"error": f"Missing required field: {field}"}), 400
+
+        # Create organization
+        result = create_organization_with_admin(
+            name=data["name"],
+            slug=data["slug"],
+            admin_email=data["admin_email"],
+            admin_name=data["admin_name"],
+            password=data["password"],
+        )
+
+        return jsonify(result), 201
+
+    except OrganizationValidationError as e:
+        return jsonify({"error": str(e)}), 400
+
+    except Exception as e:
+        # Log the error for debugging
+        import logging
+
+        logging.error(f"Error creating organization: {e}", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500

--- a/redash_global/views.py
+++ b/redash_global/views.py
@@ -54,8 +54,7 @@ def create_organization_view():
         return jsonify({"error": str(e)}), 400
 
     except Exception as e:
-        # Log the error for debugging
         import logging
 
         logging.error(f"Error creating organization: {e}", exc_info=True)
-        return jsonify({"error": "Internal server error"}), 500
+        return jsonify({"error": str(e)}), 500

--- a/redash_global/wsgi_global.py
+++ b/redash_global/wsgi_global.py
@@ -1,0 +1,9 @@
+"""WSGI entrypoint for Redash Global service.
+
+This file can be used with WSGI servers like Gunicorn:
+    gunicorn redash_global.wsgi_global:app
+"""
+
+from .app import create_global_app
+
+app = create_global_app()


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4651

Link to the Gemini summary of the refinement https://docs.google.com/document/d/12LUTT6X05AEdyO8HrtCoHTl-7zjGNkQ2JBLRoWaenIM/edit?tab=t.n7gc0govp32y

AI Disclaimer: I used clause sonnet 4 for brainstorming - help generating code faster

# Summary

This PR implements a Proof of Concept for a separate global-redash application within the same repository, designed to handle cross-organizational operations. The implementation demonstrates the viability of sharing Redash models while maintaining service separation for global administrative tasks. It may not be merged at the end but it could be a base for something big so I am openning it as PR.

# Code Strategy


### 1. Implementing a Global Redash Application 

Separate Flask application that reuses existing Redash models and database , it has a clear separation between routes, services, and authentication for reusability. Offering an Independent deployment capability while sharing the same codebase.

### 2. Adding an Organization Creation Service

We added RESTful API endpoint: `POST /global-api/organizations` . This one does a complete organization setup: Creates org, admin/default groups, and admin user. It does that via a secure authentication: Token-based authentication via `X-Global-Api-Token` header

### 3. Handling Infrastructure & Deployment
We implemented a docker integration: adding a new `global_server` command in docker-entrypoint using a separate port 5001. It guarantees a separate worker configuration also (`REDASH_GLOBAL_WEB_WORKERS`)

### 4. Added `REDASH_GLOBAL_API_TOKEN` to redash staging secrets with a proper value

### 5 Implemented the infrastructure part of it that guaranteed a clear separation between redash and global-redash

check this PR: https://github.com/metr-systems/infrastructure/pull/84

### 6. We also added the dns entry to ionos.

# QA

We did test it manually throught these steps : 

- Deploy (check [infrastructure part](https://github.com/metr-systems/infrastructure/pull/84) also)
- Run this command 

```
curl -X POST https://global-dashboard.staging.metr.systems/global-api/organizations \
  -H "Content-Type: application/json" \
  -H "X-Global-Api-Token: ---" \
  -d '{
    "name": "new org",
    "slug": "new-org",
    "admin_email": "---",
    "admin_name": "---",
    "password": "---"
  }'
```

- Check that organization was created with 
`kubectl -n staging exec -it dashboards-scheduler-68ccbb578d-tntv9 -- python manage.py org list`