### PR TITLE
Filter allowed widdget query by org

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -142,13 +142,16 @@ class MyDashboardsResource(BaseResource):
         return paginate(ordered_results, page, page_size, DashboardSerializer)
 
 
-def get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name):
+def get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, org):
     """This function adds allowed_widgets info to the data to return to frontend
     if we have a query named as follow f"allowed_widgets_{dashboard_id}".
     It returns an empty dictionary if the query does not exist"""
     # get the query having the allowed widgets information for the current dashboard
     query_name = f"allowed_widgets_{dashboard_id}"
-    query = models.Query.query.filter(models.Query.name == query_name).first()
+    query = models.Query.query.filter(
+        models.Query.name == query_name,
+        models.Query.org == org,
+    ).first()
 
     # construct the allowed_widgets dictionary from the query data
     allowed_widgets = {}
@@ -168,7 +171,7 @@ def add_allowed_widgets_info(method):
         # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
         parameter_col_name = "main_parameter"
         widgets_col_name = "widgets"
-        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name)
+        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, self.current_org)
         if allowed_widgets:
             result["allowed_widgets"] = allowed_widgets
         return result

--- a/tests/handlers/test_allowed_widgets.py
+++ b/tests/handlers/test_allowed_widgets.py
@@ -18,7 +18,11 @@ class TestAddAllowedWidgetsInfo(BaseTestCase):
         query_data_result = self.factory.create_query_result(data=data)
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
 
+        org = self.factory.org
+
         class ClassToTest:
+            current_org = org
+
             @add_allowed_widgets_info
             def test_method(self, dashboard_id):
                 return {"info": "info detail"}
@@ -45,7 +49,7 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
 
         # call function to test
-        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name)
+        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, self.factory.org)
 
         # assertions
         assert {"controller1234": ["firstQueryViz", "secondQueryViz"]} == allowed_widgets
@@ -66,7 +70,7 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
         self.factory.create_query(name=f"allowed_widgets_{dashboard_id}", latest_query_data=query_data_result)
 
         # assertions
-        assert get_allowed_widgets_info(dashboard_id, "main_parameter", widgets_col_name) == {}
+        assert get_allowed_widgets_info(dashboard_id, "main_parameter", widgets_col_name, self.factory.org) == {}
 
     def test_allowed_widgets_is_empty_if_the_query_doesnt_exists(self):
         dashboard_id = 1
@@ -74,4 +78,26 @@ class TestAllowedWidgetsDashboardResourceGet(BaseTestCase):
         widgets_col_name = "widgets"
 
         # call function to test and assert its result
-        assert get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name) == {}
+        assert get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, self.factory.org) == {}
+
+    def test_does_not_return_data_from_a_different_org(self):
+        dashboard_id = 1
+        parameter_col_name = "main_parameter"
+        widgets_col_name = "widgets"
+
+        # create a query with the same name in a different org
+        other_org = self.factory.create_org()
+        data = {
+            "rows": [{parameter_col_name: "other_org_controller", widgets_col_name: ["otherViz"]}],
+            "columns": [{"name": parameter_col_name}, {"name": widgets_col_name}],
+        }
+        query_data_result = self.factory.create_query_result(data=data)
+        self.factory.create_query(
+            name=f"allowed_widgets_{dashboard_id}",
+            latest_query_data=query_data_result,
+            org=other_org,
+        )
+
+        # querying for the current org should return nothing
+        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, self.factory.org)
+        assert allowed_widgets == {}


### PR DESCRIPTION
This PR is to document this hotfix. I will merge it immediately because I've already tested in Staging

This was causing two problems. First because if someone created a query with the same name across tenants it would fail. Second, and even worse, it was possible for one tenant to get data from another.