### PR TITLE
fix: preserve query params on by_url_identifier redirect

### DIFF
--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -1,4 +1,4 @@
-from flask import redirect, render_template, send_file
+from flask import redirect, render_template, request, send_file
 from flask_login import login_required
 from werkzeug.utils import safe_join
 
@@ -34,8 +34,12 @@ def dashboard_by_url_identifier(url_identifier, org_slug):
     current_org_obj = current_org._get_current_object()
     dashboard = models.Dashboard.get_by_url_identifier_and_org_or_404(url_identifier, current_org_obj)
 
-    # Redirect to canonical dashboard URL with org prefix
+    # Redirect to canonical dashboard URL with org prefix, preserving query params
+    # (e.g. ?p_Liegenschaft=...) since linked dashboards rely on them.
     canonical_path = f"/{org_slug}/dashboards/{dashboard.id}-{dashboard.slug}"
+    query_string = request.query_string.decode("utf-8")
+    if query_string:
+        canonical_path = f"{canonical_path}?{query_string}"
 
     return redirect(canonical_path, code=302)
 

--- a/tests/handlers/test_static.py
+++ b/tests/handlers/test_static.py
@@ -19,6 +19,28 @@ class TestDashboardByUrlIdentifier(BaseTestCase):
         expected_path = f"/{self.factory.org.slug}/dashboards/{dashboard.id}-{dashboard.slug}"
         self.assertEqual(rv.location, expected_path)
 
+    def test_redirect_preserves_query_params(self):
+        dashboard = self.factory.create_dashboard()
+        test_user = self.factory.create_user()
+
+        metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="test-id")
+        db.session.add(metr_dashboard)
+        db.session.commit()
+
+        rv = self.make_request(
+            "get",
+            "/dashboards/by_url_identifier/test-id?p_Liegenschaft=00000000-0000-0000-0000-000000000000",
+            user=test_user,
+            is_json=False,
+        )
+
+        self.assertEqual(rv.status_code, 302)
+        expected_path = (
+            f"/{self.factory.org.slug}/dashboards/{dashboard.id}-{dashboard.slug}"
+            "?p_Liegenschaft=00000000-0000-0000-0000-000000000000"
+        )
+        self.assertEqual(rv.location, expected_path)
+
     def test_not_found(self):
         # Create a user for authentication
         test_user = self.factory.create_user()


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4861

AI Disclaimer: Yes — used Claude Code

# Summary

Dashboard links built from the overview in SE dashboards (e.g. `/dashboards/by_url_identifier/anlagendetails?p_Liegenschaft=<uuid>`) were losing their query parameters during the redirect to the canonical org dashboard URL. 

The building UUID got dropped, so the dashboard couldn't open for the correct building. 

This fix restores the parameters so overview → details navigation works as intended for the SE team's templates.

# Code Strategy

The fix re-appends `request.query_string` only when present, which preserves every parameter, their order, and existing URL-encoding without parsing/reconstructing. No-param redirects don't regress.

# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Unit tests (pytest)
- [ ] E2E Tests (Cypress)
- [x] Manually (in staging)
- [ ] N/A