### PR TITLE
reserve space for stacked bottom panels in dashboard editing mode

### DIFF
--- a/client/app/components/dashboards/dashboard-grid.less
+++ b/client/app/components/dashboards/dashboard-grid.less
@@ -35,6 +35,8 @@
   }
 
   &.editing-mode {
+    margin-bottom: 160px;
+
     /* Y axis lines */
     background: linear-gradient(to right, transparent, transparent 1px, #f6f8f9 1px, #f6f8f9),
       linear-gradient(to bottom, #b3babf, #b3babf 1px, transparent 1px, transparent);
@@ -47,7 +49,7 @@
       position: absolute;
       top: 0;
       left: 0;
-      bottom: 85px;
+      bottom: 160px;
       right: 0;
       background: linear-gradient(to bottom, transparent, transparent 2px, #f6f8f9 2px, #f6f8f9 5px),
         linear-gradient(to left, #b3babf, #b3babf 1px, transparent 1px, transparent);


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4665

AI Disclaimer: Yes

# Summary

Editing mode stacks two fixed bottom panels as you can see in the linked issue, this was hiding the widgets even when we scroll till the end. Here we bump the grid's margin-bottom and overlay bottom to 160px so widgets and grid lines aren't hidden behind them when we scroll to the end.

# Code Strategy

We have AddWidgetContainer that sits lowest with bottom at 20px
We also have UrlIdentifierContainer that sits at bottom 95px with a height of 50px this makes it 145px , we add 15px for clear space.
 
# QA

Manually on staging: you can check it here in edit mode https://dashboard.staging.metr.systems/staging/dashboards/59-dynamicwidgetstest?edit&p_Zeitraum=d_this_week&p_value=test2

