### PR TITLE
allowed widgets - fix first repack after edit 

### DIFF
--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -239,13 +239,13 @@ class DashboardGrid extends React.Component {
 
   applyLayoutsOrder(layouts) {
     const { editedlayoutsOrder, widgets, setEditedlayoutsOrder } = this.props;
-    const { layoutsOrder } = this.state;
+    const orderToUse = editedlayoutsOrder.length > 0 ? editedlayoutsOrder : this.state.layoutsOrder;
 
     if (editedlayoutsOrder.length > 0) {
       this.setLayoutsOrder(editedlayoutsOrder);
       setEditedlayoutsOrder([]);
     }
-    return keepLayoutsOrder(layoutsOrder, layouts[MULTI], widgets);
+    return keepLayoutsOrder(orderToUse, layouts[MULTI], widgets);
   }
 
   normalizeTo = (layout) => ({


### PR DESCRIPTION
Part of https://github.com/metr-systems/backlog/issues/4903

AI Disclaimer: Used to double check concern

# Summary

In this code we fix an invisible bug (that corrects itself) and use edited order directly on first repack after editing


# Code Strategy

applyLayoutsOrder passed the old order (state.layoutsOrder) to keepLayoutsOrder, and only scheduled the new editedlayoutsOrder for later via setState. Because setState is async, the first repack after an edit still used the old order.

This was never visible to the user. The stale repack's setState makes RGL run onLayoutChange again right away (in componentDidUpdate, before anything is drawn on screen), and that second run uses the new order. So the user only ever sees the correct layout. It also never affected saved data (the order lives in each widget's options.position). I could not reproduce any flicker even with 6x CPU throttling in DevTools (that allows you to see how window change slowly). 

This change uses the new order for the repack directly (falling back to the old order when there is no pending edit), so we no longer rely on that second render to fix things up. Nothing changes on screen.

# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Manually (checked on staging - looks good)
