### PR TITLE
Feature/global app scaffold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN yarn config set network-timeout 300000
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn --frozen-lockfile; fi
 
 COPY --chown=redash client /frontend/client
+COPY --chown=redash redash_global /frontend/redash_global
 COPY --chown=redash webpack.config.js /frontend/
 RUN <<EOF
   if [ "x$skip_frontend_build" = "x" ]; then

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -49,6 +49,14 @@ server() {
   exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
 }
 
+global_server() {
+  # Recycle gunicorn workers every n-th request. See https://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
+  MAX_REQUESTS=${MAX_REQUESTS:-1000}
+  MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
+  TIMEOUT=${REDASH_GUNICORN_TIMEOUT:-60}
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5001 --name redash-global -w${REDASH_GLOBAL_WEB_WORKERS:-2} redash_global.wsgi_global:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
+}
+
 create_db() {
   exec /app/manage.py database create_tables
 }
@@ -60,6 +68,7 @@ help() {
   echo ""
 
   echo "server -- start Redash server (with gunicorn)"
+  echo "global_server -- start Redash Global server (with gunicorn)"
   echo "worker -- start a single RQ worker"
   echo "dev_worker -- start a single RQ worker with code reloading"
   echo "scheduler -- start an rq-scheduler instance"
@@ -96,6 +105,10 @@ case "$1" in
   server)
     shift
     server
+    ;;
+  global_server)
+    shift
+    global_server
     ;;
   scheduler)
     shift

--- a/redash_global/__init__.py
+++ b/redash_global/__init__.py
@@ -1,0 +1,1 @@
+"""Redash Global - cross-organization admin app"""

--- a/redash_global/app.py
+++ b/redash_global/app.py
@@ -1,0 +1,25 @@
+from flask import Flask
+
+from redash import settings
+from redash.models.base import db
+
+
+def create_global_app():
+    """Create and configure the Redash Global Flask application."""
+    app = Flask(
+        __name__,
+        static_folder=settings.STATIC_ASSETS_PATH,
+        static_url_path="/static",
+    )
+
+    # Reuse Redash's database connection — single shared PostgreSQL database,
+    # no second connection pool, full access to the existing models later on.
+    app.config["SQLALCHEMY_DATABASE_URI"] = settings.SQLALCHEMY_DATABASE_URI
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+
+    from redash_global.routes import global_blueprint
+
+    app.register_blueprint(global_blueprint)
+
+    return app

--- a/redash_global/client/components/GlobalApplicationArea/index.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/index.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function GlobalApplicationArea() {
+  return <div>Work in progress</div>;
+}

--- a/redash_global/client/global.html
+++ b/redash_global/client/global.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <div id="application-root"></div>
+  </body>
+</html>

--- a/redash_global/client/index.js
+++ b/redash_global/client/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import GlobalApplicationArea from "./components/GlobalApplicationArea";
+
+ReactDOM.render(<GlobalApplicationArea />, document.getElementById("application-root"));

--- a/redash_global/routes.py
+++ b/redash_global/routes.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+from redash_global.views.index import index_view
+
+global_blueprint = Blueprint("global", __name__)
+
+global_blueprint.add_url_rule("/", methods=["GET"], view_func=index_view, endpoint="index")

--- a/redash_global/views/index.py
+++ b/redash_global/views/index.py
@@ -1,0 +1,9 @@
+from flask import send_file
+from werkzeug.utils import safe_join
+
+from redash import settings
+
+
+def index_view():
+    full_path = safe_join(settings.STATIC_ASSETS_PATH, "global.html")
+    return send_file(full_path, max_age=0, conditional=True)

--- a/redash_global/wsgi_global.py
+++ b/redash_global/wsgi_global.py
@@ -1,0 +1,3 @@
+from .app import create_global_app
+
+app = create_global_app()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,7 @@ const config = {
       "./client/app/assets/less/main.less",
       "./client/app/assets/less/ant.less"
     ],
+    global_app: ["./redash_global/client/index.js"],
     server: ["./client/app/assets/less/server.less"]
   },
   output: {
@@ -94,16 +95,22 @@ const config = {
     new HtmlWebpackPlugin({
       template: "./client/app/index.html",
       filename: "index.html",
-      excludeChunks: ["server"],
+      excludeChunks: ["server", "global_app"],
       release: process.env.BUILD_VERSION || "dev",
       staticPath,
       baseHref,
       title: htmlTitle
     }),
     new HtmlWebpackPlugin({
+      template: "./redash_global/client/global.html",
+      filename: "global.html",
+      chunks: ["global_app"],
+      title: "Global Admin"
+    }),
+    new HtmlWebpackPlugin({
       template: "./client/app/multi_org.html",
       filename: "multi_org.html",
-      excludeChunks: ["server"]
+      excludeChunks: ["server", "global_app"]
     }),
     isProduction &&
       new MiniCssExtractPlugin({
@@ -145,6 +152,9 @@ const config = {
           {
             loader: require.resolve("babel-loader"),
             options: {
+              // redash_global/client lives outside client/, so .babelrc isn't
+              // found by the default upward search — point at it explicitly.
+              configFile: path.resolve(__dirname, "client/.babelrc"),
               plugins: [
                 isHotReloadingEnabled && require.resolve("react-refresh/babel")
               ].filter(Boolean)
@@ -155,7 +165,7 @@ const config = {
       },
       {
         test: /\.html$/,
-        exclude: [/node_modules/, /index\.html/, /multi_org\.html/],
+        exclude: [/node_modules/, /index\.html/, /multi_org\.html/, /global\.html/],
         use: [
           {
             loader: "raw-loader"
@@ -246,6 +256,9 @@ const config = {
     devMiddleware: {
       index: "/static/index.html",
       publicPath: staticPath,
+      // Write the global bundle to disk so the standalone global Flask server
+      // (on its own port) can serve global.html + global_app.js directly.
+      writeToDisk: filePath => /global/.test(filePath),
       stats: {
         modules: false,
         chunkModules: false


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4906

AI Disclaimer: yes claude , in the poc i relied on it a lot but for this i had to study the webpack configuration and check details what we are doing 

# Summary

This PR introduces an initial Redash Global (redash_global/), a second Flask app that will host the cross-organization Global Dashboard Management System. It shares the same PostgreSQL database as the main Redash app but runs as its own process on its own port.

Right now it does exactly one thing: serve a single React page that says "Work in progress" : no API, no auth, no data models, no CLI. It's a clean, minimal starting point to build the real admin UI on top of. 

You can see it live on staging: https://global-dashboard.staging.metr.systems/ , knowing that i needed also to deploy changes in this infrastructure PR to make it work https://github.com/metr-systems/infrastructure/pull/84/changes

What's added:

**Backend** :  
    - `create_global_app()` factory that reuses Redash's settings and DB, registers one blueprint with a single / route that serves the webpack-built `global.html`. 
    - A `wsgi_global.py` entrypoint for gunicorn.
    
**Frontend** : 
    - a React entry (`index.js`) that mounts a self-contained `GlobalApplicationArea` placeholder into `#application-root`, plus a minimal `global.html` template.
    
**Build & run wiring** : 
    - a new webpack entry (global_app) + HtmlWebpackPlugin that build the global bundle and its global.html page
    - a `global_server` docker-entrypoint command (gunicorn on port 5001)
    - and a Dockerfile line to copy `redash_global/ `into the frontend build image.

# Code Strategy

- Shared database, separate app
- Served at /
- Not exposing anything for now 
- Very minimal frontend for now
- Same webpack pipeline as main app, there is only one point of difference and only for the devserver (explanation follows)

How the main app works in dev: You run `yarn start`, which launches the webpack dev server on :8080. That server keeps all the built bundles in memory and serves them straight to the browser, nothing is written to dist/ on disk. The browser talks directly to the dev server, and API calls are forwarded to the real Redash backend via the proxy rules. This is what makes hot-reloading fast: rebuilds stay in memory, no disk I/O.

we could have proxied the global app through the dev server too (like the main app's proxy rules), but that only makes sense once the global app has an API and needs hot-reload through :8080 , which the current bootstrap doesn't. Serving from disk is the simplest thing that lets the separate Flask process work today, and the dev-proxy route stays open for later

- Serves its own static assets from dist/ and runs as a gunicorn process on port 5001 (new global_server entrypoint command)


# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Manually, on staging , you can see it here https://global-dashboard.staging.metr.systems/
