### PR TITLE
Fix/<a> having dashboard by identifier as link

### DIFF
--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -217,7 +217,7 @@ DashboardComponent.propTypes = {
   dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-function DashboardPage({ dashboardSlug, dashboardId, onError }) {
+function DashboardPage({ dashboardSlug, dashboardId, dashboardUrlIdentifier, onError }) {
   const [dashboard, setDashboard] = useState(null);
   const [loading, setLoading] = useState(true);
   const handleError = useImmutableCallback(onError);
@@ -225,19 +225,19 @@ function DashboardPage({ dashboardSlug, dashboardId, onError }) {
 
   useEffect(() => {
     setLoading(true);
-    Dashboard.get({ id: dashboardId, slug: dashboardSlug })
+    Dashboard.get({ id: dashboardId, slug: dashboardSlug, urlIdentifier: dashboardUrlIdentifier })
       .then((dashboardData) => {
         recordEvent("view", "dashboard", dashboardData.id);
         setDashboard(dashboardData);
 
-        // if loaded by slug, update location url to use the id
+        // if loaded by slug or url identifier, update location url to use the canonical id
         if (!dashboardId) {
           location.setPath(url.parse(dashboardData.url).pathname, true);
         }
       })
       .catch(handleError)
       .finally(() => setLoading(false));
-  }, [dashboardId, dashboardSlug, handleError]);
+  }, [dashboardId, dashboardSlug, dashboardUrlIdentifier, handleError]);
 
   return (
     <div className="dashboard-page">
@@ -255,12 +255,14 @@ function DashboardPage({ dashboardSlug, dashboardId, onError }) {
 DashboardPage.propTypes = {
   dashboardSlug: PropTypes.string,
   dashboardId: PropTypes.string,
+  dashboardUrlIdentifier: PropTypes.string,
   onError: PropTypes.func,
 };
 
 DashboardPage.defaultProps = {
   dashboardSlug: null,
   dashboardId: null,
+  dashboardUrlIdentifier: null,
   onError: PropTypes.func,
 };
 
@@ -269,6 +271,15 @@ routes.register(
   "Dashboards.LegacyViewOrEdit",
   routeWithUserSession({
     path: "/dashboard/:dashboardSlug",
+    render: (pageProps) => <DashboardPage {...pageProps} />,
+  })
+);
+
+// metr dashboard by url identifier
+routes.register(
+  "Dashboards.ByUrlIdentifier",
+  routeWithUserSession({
+    path: "/dashboards/by_url_identifier/:dashboardUrlIdentifier",
     render: (pageProps) => <DashboardPage {...pageProps} />,
   })
 );

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -162,7 +162,10 @@ function transformResponse(data) {
 
 const saveOrCreateUrl = (data) => (data.id ? `api/dashboards/${data.id}` : "api/dashboards");
 const DashboardService = {
-  get: ({ id, slug }) => {
+  get: ({ id, slug, urlIdentifier }) => {
+    if (urlIdentifier) {
+      return axios.get(`api/dashboards/by_url_identifier/${urlIdentifier}`).then(transformResponse);
+    }
     const params = {};
     if (!id) {
       params.legacy = null;

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -138,7 +138,12 @@ api.add_org_resource(
 api.add_org_resource(AlertListResource, "/api/alerts", endpoint="alerts")
 
 api.add_org_resource(DashboardListResource, "/api/dashboards", endpoint="dashboards")
-api.add_org_resource(DashboardResource, "/api/dashboards/<dashboard_id>", endpoint="dashboard")
+api.add_org_resource(
+    DashboardResource,
+    "/api/dashboards/<dashboard_id>",
+    "/api/dashboards/by_url_identifier/<url_identifier>",
+    endpoint="dashboard",
+)
 api.add_org_resource(
     PublicDashboardResource,
     "/api/dashboards/public/<token>",

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -165,13 +165,14 @@ def get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name,
 
 
 def add_allowed_widgets_info(method):
-    def wrapper(self, dashboard_id):
-        result = method(self, dashboard_id)
+    def wrapper(self, dashboard_id=None, url_identifier=None):
+        result = method(self, dashboard_id=dashboard_id, url_identifier=url_identifier)
 
         # add allowed_widgets to the dashboard information to return in case it exists and it is not empty
+        lookup_id = dashboard_id if dashboard_id is not None else result["id"]
         parameter_col_name = "main_parameter"
         widgets_col_name = "widgets"
-        allowed_widgets = get_allowed_widgets_info(dashboard_id, parameter_col_name, widgets_col_name, self.current_org)
+        allowed_widgets = get_allowed_widgets_info(lookup_id, parameter_col_name, widgets_col_name, self.current_org)
         if allowed_widgets:
             result["allowed_widgets"] = allowed_widgets
         return result
@@ -182,7 +183,7 @@ def add_allowed_widgets_info(method):
 class DashboardResource(BaseResource):
     @require_permission("list_dashboards")
     @add_allowed_widgets_info
-    def get(self, dashboard_id=None):
+    def get(self, dashboard_id=None, url_identifier=None):
         """
         Retrieves a dashboard.
 
@@ -217,11 +218,14 @@ class DashboardResource(BaseResource):
         :>json string widget.created_at: ISO format timestamp for widget creation
         :>json string widget.updated_at: ISO format timestamp for last widget modification
         """
-        if request.args.get("legacy") is not None:
-            fn = models.Dashboard.get_by_slug_and_org
+        if url_identifier is not None:
+            dashboard = models.Dashboard.get_by_url_identifier_and_org_or_404(url_identifier, self.current_org)
         else:
-            fn = models.Dashboard.get_by_id_and_org
-        dashboard = get_object_or_404(fn, dashboard_id, self.current_org)
+            if request.args.get("legacy") is not None:
+                fn = models.Dashboard.get_by_slug_and_org
+            else:
+                fn = models.Dashboard.get_by_id_and_org
+            dashboard = get_object_or_404(fn, dashboard_id, self.current_org)
 
         require_dashboard_group_access(dashboard, self.current_user)
 

--- a/tests/handlers/test_dashboards.py
+++ b/tests/handlers/test_dashboards.py
@@ -168,6 +168,27 @@ class TestDashboardResourceGetByAdmin(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertIsNone(rv.json["url_identifier"])
 
+    def test_get_dashboard_by_url_identifier(self):
+        """Dashboard can be resolved through the by_url_identifier JSON endpoint."""
+        dashboard = self.factory.create_dashboard()
+        admin = self.factory.create_admin()
+        db.session.flush()
+
+        metr_dashboard = MetrDashboard(dashboard_id=dashboard.id, org_id=dashboard.org_id, url_identifier="details")
+        db.session.add(metr_dashboard)
+        db.session.commit()
+
+        rv = self.make_request("get", "/api/dashboards/by_url_identifier/details", user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["id"], dashboard.id)
+        self.assertEqual(rv.json["url_identifier"], "details")
+
+    def test_get_dashboard_by_unknown_url_identifier(self):
+        """An unknown url_identifier returns 404."""
+        admin = self.factory.create_admin()
+        rv = self.make_request("get", "/api/dashboards/by_url_identifier/does-not-exist", user=admin)
+        self.assertEqual(rv.status_code, 404)
+
 
 class TestDashboardResourceGetByCustom(BaseTestCase):
     def test_get_dashboard_by_custom_requires_group_access(self):


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4919

AI Disclaimer: Yes claude , assisted in finding the fix and its implementation

# Summary

Clicking a dashboard link that uses `by_url_identifier` (e.g. from inside a visualization) showed an error page, and only worked after a manual refresh. This PR fixes it so the dashboard opens directly, with no refresh.

# Code Strategy

The `by_url_identifier` redirect only existed server-side. When such a link is clicked inside the app, Redash's global navigation handler routes it client-side, so the request never reaches the server and the redirect never runs — hence the error (a refresh worked because it's a real server request).

Rather than force a full page reload, we resolve it in-app:

- New JSON endpoint GET `/api/dashboards/by_url_identifier/<url_identifier>` to fetch the dashboard by its identifier (org-scoped, same access checks as the id/slug path).
- `Dashboard.get `can call it via `urlIdentifier`.
- A client route renders `DashboardPage` and rewrites the URL to the canonical `{id}-{slug}`.

# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Manually (on staging)
- [x] Unit tests

# Notes: 

This is a fix and will be deployed today