### PR TITLE
Match main Redash's security in global redash

### DIFF
--- a/redash_global/security.py
+++ b/redash_global/security.py
@@ -2,17 +2,17 @@ import os
 
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_talisman import talisman
 from flask_wtf.csrf import CSRFProtect
 
 from redash import settings
 
 csrf = CSRFProtect()
 
+talisman = talisman.Talisman()
+
 GLOBAL_THROTTLE_LOGIN_PATTERN = os.environ.get("GLOBAL_THROTTLE_LOGIN_PATTERN", "10/hour")
 
-# Dedicated Limiter instance rather than reusing redash.limiter, to keep the
-# two apps decoupled, but pointed at the same Redis storage so limits hold
-# across processes/pods.
 limiter = Limiter(key_func=get_remote_address, storage_uri=settings.LIMITER_STORAGE)
 
 
@@ -22,3 +22,27 @@ def init_app(app):
     app.config["SESSION_COOKIE_NAME"] = os.environ.get("GLOBAL_SESSION_COOKIE_NAME", "global_admin_session")
     app.config["RATELIMIT_ENABLED"] = settings.RATELIMIT_ENABLED
     limiter.init_app(app)
+
+    # Transport/header hardening, mirroring redash/security.py so the global
+    # admin surface gets the same Secure/HttpOnly cookie flags, HTTPS + HSTS
+    # enforcement, frame-options, CSP, and referrer policy as the main app.
+    talisman.init_app(
+        app,
+        feature_policy=settings.FEATURE_POLICY,
+        force_https=settings.ENFORCE_HTTPS,
+        force_https_permanent=settings.ENFORCE_HTTPS_PERMANENT,
+        force_file_save=settings.ENFORCE_FILE_SAVE,
+        frame_options=settings.FRAME_OPTIONS,
+        frame_options_allow_from=settings.FRAME_OPTIONS_ALLOW_FROM,
+        strict_transport_security=settings.HSTS_ENABLED,
+        strict_transport_security_preload=settings.HSTS_PRELOAD,
+        strict_transport_security_max_age=settings.HSTS_MAX_AGE,
+        strict_transport_security_include_subdomains=settings.HSTS_INCLUDE_SUBDOMAINS,
+        content_security_policy=settings.CONTENT_SECURITY_POLICY,
+        content_security_policy_report_uri=settings.CONTENT_SECURITY_POLICY_REPORT_URI,
+        content_security_policy_report_only=settings.CONTENT_SECURITY_POLICY_REPORT_ONLY,
+        content_security_policy_nonce_in=settings.CONTENT_SECURITY_POLICY_NONCE_IN,
+        referrer_policy=settings.REFERRER_POLICY,
+        session_cookie_secure=settings.SESSION_COOKIE_SECURE,
+        session_cookie_http_only=settings.SESSION_COOKIE_HTTPONLY,
+    )

--- a/tests/test_global_security.py
+++ b/tests/test_global_security.py
@@ -1,0 +1,43 @@
+from redash import security as redash_security
+from redash_global import security as global_security
+from tests.test_global_auth import GlobalBaseTestCase
+
+TALISMAN_CONFIG_ATTRS = (
+    "feature_policy",
+    "force_https",
+    "force_https_permanent",
+    "force_file_save",
+    "frame_options",
+    "frame_options_allow_from",
+    "strict_transport_security",
+    "strict_transport_security_preload",
+    "strict_transport_security_max_age",
+    "strict_transport_security_include_subdomains",
+    "content_security_policy",
+    "content_security_policy_report_uri",
+    "content_security_policy_report_only",
+    "content_security_policy_nonce_in",
+    "referrer_policy",
+    "session_cookie_secure",
+)
+
+
+class GlobalTalismanParityTest(GlobalBaseTestCase):
+    """Redash Global mirrors the main app's Talisman hardening. flask-talisman
+    stores every ``init_app`` keyword as an attribute on the ``Talisman``
+    instance, so once both apps have been built (main app by BaseTestCase,
+    global app by GlobalBaseTestCase) we can compare the two singletons
+    attribute-for-attribute and fail if the configs ever drift apart.
+    """
+
+    def test_talisman_config_matches_main_redash(self):
+        redash_config = {attr: getattr(redash_security.talisman, attr) for attr in TALISMAN_CONFIG_ATTRS}
+        global_config = {attr: getattr(global_security.talisman, attr) for attr in TALISMAN_CONFIG_ATTRS}
+
+        self.assertEqual(redash_config, global_config)
+
+    def test_session_cookie_http_only_matches_main_redash(self):
+        self.assertEqual(
+            self.app.config["SESSION_COOKIE_HTTPONLY"],
+            self.global_app.config["SESSION_COOKIE_HTTPONLY"],
+        )


### PR DESCRIPTION
Closes  https://github.com/metr-systems/backlog/issues/4942


AI Disclaimer: I did use claude opus to double check if global redash and main are on the same security level and to plan if anything is missing and also to assist


# Summary

Global redash was missing the protections the main app gets from `flask-talisman`. This brings it up to at least the same level.

# Code Strategy

- Add a dedicated Talisman instance in `security.py`, configured from the same redash settings the main app reads. One set of env vars (REDASH_ENFORCE_HTTPS, REDASH_HSTS_*, REDASH_CONTENT_SECURITY_POLICY, ...) now hardens both apps the same way, instead of the two drifting apart.
- This adds HTTPS + HSTS enforcement, X-Frame-Options, a Content-Security-Policy, a referrer policy, and Secure/HttpOnly session cookie flags.
- Use a dedicated instance rather than the main app's, to keep the two apps decoupled, matching the existing separate csrf and limiter instances.