### PR TITLE
Feature/stick viz searchbar header

### DIFF
--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -152,13 +152,33 @@
     width: 100%;
     height: 100%;
 
+    // Resolve the height chain from the absolute container down to .ant-table so
+    // flex-grow can bound the table to the available space. Without this the
+    // table grows to its content, the outer container scrolls instead, and the
+    // sticky <th> header rides away with it.
+    .table-fixed-header,
+    .ant-spin-nested-loading,
+    .ant-spin-container {
+      height: 100%;
+    }
 
     .ant-spin-container {
       display: flex;
       flex-direction: column;
 
+      // Make .ant-table the bounded vertical scroll container so the sticky <th>
+      // header anchors to it and stays pinned while the rows scroll — the same
+      // arrangement the .edit-visualization-dialog block below relies on.
       .ant-table {
         flex-grow: 1;
+        overflow: auto;
+      }
+
+      // Keep the wrappers between the sticky <th> and .ant-table transparent so a
+      // clipping wrapper doesn't break the sticky anchoring.
+      .ant-table-container,
+      .ant-table-content {
+        overflow: visible;
       }
     }
   }

--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -16,6 +16,17 @@
     table {
       border-top: 0;
 
+      // The search bar (when present) forms the first header row — pin it to the top.
+      th.table-visualization-search {
+        position: sticky !important;
+        top: 0;
+        z-index: 2;
+        background: #fafafa !important;
+      }
+
+      // Column titles — pin as a sticky header row. Default to the very top so
+      // that when there is no search bar (single header row) they sit flush and
+      // no rows can scroll into the space above them.
       th:not(.table-visualization-search) {
         position: sticky !important;
         left: 0;
@@ -23,6 +34,12 @@
         border-top: 0;
         z-index: 1;
         background: #fafafa !important;
+      }
+
+      // When the search bar is present the titles are the second header row, so
+      // offset them below it (by the search row's height) instead of the top.
+      tr:nth-child(2) th:not(.table-visualization-search) {
+        top: 50px; // height of the search row
       }
     }
   }
@@ -146,6 +163,26 @@
     }
   }
   /* END */
+}
+
+// In the visualization edit dialog there is no fixed layout, so by default the
+// whole table grows and the outer .visualization-preview scrolls, carrying the
+// header away. Bound the table's own height instead so it becomes the scroll
+// container: the sticky <th> then anchors to .ant-table (its nearest scrolling
+// ancestor) and the rows scroll inside the table while the header stays pinned.
+// This mirrors the .query-fixed-layout block above, which already works.
+.edit-visualization-dialog .visualization-preview {
+  .ant-table {
+    max-height: calc(100vh - 220px); 
+    overflow: auto;
+  }
+
+  // Keep the antd wrappers between the sticky <th> and .ant-table transparent,
+  // otherwise a clipping wrapper would break the sticky anchoring.
+  .ant-table-container,
+  .ant-table-content {
+    overflow: visible;
+  }
 }
 
 .table-visualization-search-info-content {


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4952

AI Disclaimer: I used Claude Opus extensively to help implement this change, as CSS is not my strongest area, although I’m comfortable working with it. I reviewed and validated the final result.

# Summary

Here we make the table visualization's header (search bar + column titles) stay frozen at the top while we scroll, and this everywhere the table appears


# Code Strategy

The whole strategy is to simply: force the table itself to be the scroll container, then let the header stick to it.

# QA

Manually on staging, you can check the query here https://dashboard.staging.metr.systems/staging/queries/111 and you can see it used in a widget in this dashboard https://dashboard.staging.metr.systems/staging/dashboards/71-test-asdas

How it appears? (screenshots from staging)

- On the query page 

<img width="1981" height="1215" alt="Screenshot 2026-07-21 at 16 12 26" src="https://github.com/user-attachments/assets/93ffd27d-b6a3-4e6e-8942-551f0c28b2ab" />
<img width="1969" height="1280" alt="Screenshot 2026-07-21 at 16 12 42" src="https://github.com/user-attachments/assets/a8d9a475-e5ef-412e-8fc8-32e67af042b4" />
<img width="2040" height="1263" alt="Screenshot 2026-07-21 at 16 12 54" src="https://github.com/user-attachments/assets/2be5d110-f3d5-4362-be8d-9f754097bc04" />

- On the dashboard page 

<img width="1964" height="903" alt="Screenshot 2026-07-21 at 16 13 09" src="https://github.com/user-attachments/assets/618c1a50-cf41-42e6-ba50-82c05287a9cc" />
