### PR TITLE
Add identifier to data sources

### DIFF
--- a/client/app/pages/data-sources/EditDataSource.jsx
+++ b/client/app/pages/data-sources/EditDataSource.jsx
@@ -5,14 +5,17 @@ import PropTypes from "prop-types";
 import Modal from "antd/lib/modal";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
 import navigateTo from "@/components/ApplicationArea/navigateTo";
+import EditInPlace from "@/components/EditInPlace";
 import LoadingState from "@/components/items-list/components/LoadingState";
 import DynamicForm from "@/components/dynamic-form/DynamicForm";
 import helper from "@/components/dynamic-form/dynamicFormHelper";
 import HelpTrigger, { TYPES as HELP_TRIGGER_TYPES } from "@/components/HelpTrigger";
 import wrapSettingsTab from "@/components/SettingsWrapper";
 
+import { axios } from "@/services/axios";
 import DataSource, { IMG_ROOT } from "@/services/data-source";
 import notification from "@/services/notification";
+import recordEvent from "@/services/recordEvent";
 import routes from "@/services/routes";
 
 import i18next from "i18next";
@@ -52,6 +55,40 @@ class EditDataSource extends React.Component {
         const message = get(error, "response.data.message", "Failed saving.");
         errorCallback(message);
       });
+  };
+
+  // Mirrors useUpdateQueryIdentifier: validate first, only then save. Written as
+  // a method rather than a hook because this page is a class component.
+  updateDataSourceIdentifier = async (dataSourceIdentifier) => {
+    const { dataSource } = this.state;
+    recordEvent("edit_data_source_identifier", "datasource", dataSource.id);
+
+    // skip validation if empty value
+    if (dataSourceIdentifier) {
+      try {
+        const response = await axios.post(`api/data_sources/${dataSource.id}/data_source_identifier/validate`, {
+          data_source_identifier: dataSourceIdentifier,
+        });
+        if (!response.valid) {
+          if (response.errors) {
+            response.errors.forEach((error) => notification.error(error));
+          }
+          return;
+        }
+      } catch (error) {
+        notification.error(i18next.t("DataSources:Failed to validate data source identifier"));
+        return;
+      }
+    }
+
+    try {
+      const saved = await DataSource.save({ ...dataSource, data_source_identifier: dataSourceIdentifier });
+      // Merge rather than replace: the POST response has no view_only, which the
+      // GET that populated this page does provide.
+      this.setState({ dataSource: { ...dataSource, ...saved } });
+    } catch (error) {
+      notification.error(get(error, "response.data.message", "Failed saving."));
+    }
   };
 
   deleteDataSource = (callback) => {
@@ -130,6 +167,15 @@ class EditDataSource extends React.Component {
         <div className="text-center m-b-10">
           <img className="p-5" src={`${IMG_ROOT}/${type.type}.png`} alt={type.name} width="64" />
           <h3 className="m-0">{type.name}</h3>
+          <div className="data-source-identifier">
+            <span className="data-source-identifier-label">{i18next.t("DataSources:Identifier:")}</span>{" "}
+            <EditInPlace
+              isEditable={!dataSource.data_source_identifier}
+              onDone={this.updateDataSourceIdentifier}
+              value={dataSource.data_source_identifier || ""}
+              placeholder={i18next.t("DataSources:Set data source identifier")}
+            />
+          </div>
         </div>
         <div className="col-md-4 col-md-offset-4 m-b-10">
           <DynamicForm {...formProps} />

--- a/migrations/versions/666406e70679_add_metrdatasource_with_data_source_.py
+++ b/migrations/versions/666406e70679_add_metrdatasource_with_data_source_.py
@@ -1,0 +1,37 @@
+"""add MetrDataSource with data_source_identifier
+
+Revision ID: 666406e70679
+Revises: 0cf0ec9c5d17
+Create Date: 2026-07-30 15:59:18.645688
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '666406e70679'
+down_revision = '0cf0ec9c5d17'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('metr_data_source',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('data_source_id', sa.Integer(), nullable=False),
+    sa.Column('org_id', sa.Integer(), nullable=False),
+    sa.Column('data_source_identifier', sa.String(length=100), nullable=True),
+    sa.ForeignKeyConstraint(['data_source_id'], ['data_sources.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_metr_data_source_org_id'), 'metr_data_source', ['org_id'], unique=False)
+    op.create_index(op.f('ix_metr_data_source_data_source_id'), 'metr_data_source', ['data_source_id'], unique=True)
+    op.create_index('uq_metr_data_source_org_data_source_identifier', 'metr_data_source', ['org_id', 'data_source_identifier'], unique=True, postgresql_where=sa.text('data_source_identifier IS NOT NULL'))
+
+
+def downgrade():
+    op.drop_index('uq_metr_data_source_org_data_source_identifier', table_name='metr_data_source', postgresql_where=sa.text('data_source_identifier IS NOT NULL'))
+    op.drop_index(op.f('ix_metr_data_source_data_source_id'), table_name='metr_data_source')
+    op.drop_index(op.f('ix_metr_data_source_org_id'), table_name='metr_data_source')
+    op.drop_table('metr_data_source')

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -57,6 +57,9 @@ from redash.handlers.groups import (
 from redash.handlers.metr_dashboards import (
     MetrDashboardUrlIdentifierValidationResource,
 )
+from redash.handlers.metr_data_sources import (
+    MetrDataSourceIdentifierValidationResource,
+)
 from redash.handlers.metr_queries import (
     MetrQueryIdentifierListResource,
     MetrQueryIdentifierValidationResource,
@@ -240,6 +243,11 @@ api.add_org_resource(
     MetrQueryIdentifierListResource,
     "/api/queries/query_identifiers",
     endpoint="query_query_identifiers",
+)
+api.add_org_resource(
+    MetrDataSourceIdentifierValidationResource,
+    "/api/data_sources/<data_source_id>/data_source_identifier/validate",
+    endpoint="data_source_data_source_identifier_validate",
 )
 
 api.add_org_resource(QuerySearchResource, "/api/queries/search", endpoint="queries_search")

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -68,6 +68,20 @@ class DataSourceResource(BaseResource):
         data_source.name = req["name"]
         models.db.session.add(data_source)
 
+        if "data_source_identifier" in req:
+            # Route data_source_identifier to the MetrDataSource, mirroring how
+            # query_identifier is routed to MetrQuery in the query handler.
+            # "" is coerced to NULL so the partial unique index applies.
+            # Pass data_source=data_source so the backref is populated immediately —
+            # otherwise the cached data_source.metr_data_source = None survives the
+            # commit (session uses expire_on_commit=False) and to_dict reads stale.
+            data_source_identifier = req["data_source_identifier"] or None
+            metr_data_source = data_source.metr_data_source
+            if not metr_data_source:
+                metr_data_source = models.MetrDataSource(data_source=data_source, org_id=data_source.org_id)
+            metr_data_source.data_source_identifier = data_source_identifier
+            models.db.session.add(metr_data_source)
+
         try:
             models.db.session.commit()
         except IntegrityError as e:

--- a/redash/handlers/metr_data_sources.py
+++ b/redash/handlers/metr_data_sources.py
@@ -1,0 +1,32 @@
+from flask import jsonify, request
+
+from redash import models
+from redash.handlers.base import BaseResource
+from redash.permissions import require_admin
+from redash.utils import slugify
+
+
+class MetrDataSourceIdentifierValidationResource(BaseResource):
+    @require_admin
+    def post(self, data_source_id):
+        data_source_identifier = request.get_json().get("data_source_identifier", None)
+
+        # Validate format and uniqueness
+        if not data_source_identifier:
+            errors = ["Data source identifier is required"]
+        elif data_source_identifier != slugify(data_source_identifier):
+            errors = ["Not a valid slug"]
+        elif (
+            models.db.session.query(models.MetrDataSource)
+            .filter(
+                models.MetrDataSource.org_id == self.current_org.id,
+                models.MetrDataSource.data_source_identifier == data_source_identifier,
+                models.MetrDataSource.data_source_id != data_source_id,
+            )
+            .first()
+        ):
+            errors = ["Already used data source identifier"]
+        else:
+            errors = []
+
+        return jsonify({"valid": not errors, "errors": errors})

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -148,6 +148,9 @@ class DataSource(BelongsToOrgMixin, db.Model):
             "paused": self.paused,
             "pause_reason": self.pause_reason,
             "supports_auto_limit": self.query_runner.supports_auto_limit,
+            "data_source_identifier": (
+                self.metr_data_source.data_source_identifier if self.metr_data_source else None
+            ),
         }
 
         if all:
@@ -292,6 +295,47 @@ class DataSource(BelongsToOrgMixin, db.Model):
     def groups(self):
         groups = DataSourceGroup.query.filter(DataSourceGroup.data_source == self)
         return dict([(group.group_id, group.view_only) for group in groups])
+
+
+@generic_repr("id", "data_source_id", "org_id", "data_source_identifier")
+class MetrDataSource(db.Model):
+    """
+    Extends DataSource with METR-specific fields.
+    Mirrors MetrQuery and MetrDashboard.
+
+    The identifier is filled in by hand and matched on across orgs, so a
+    deployment can find a customer org's copy of a data source without a
+    mapping table and without relying on the name.
+    """
+
+    id = primary_key("MetrDataSource")
+    data_source_id = Column(
+        key_type("DataSource"),
+        db.ForeignKey("data_sources.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    org_id = Column(key_type("Organization"), nullable=False, index=True)
+    data_source_identifier = Column(db.String(100), nullable=True)
+    data_source = db.relationship(
+        DataSource,
+        backref=db.backref("metr_data_source", cascade="delete", uselist=False),
+    )
+
+    __tablename__ = "metr_data_source"
+
+    __table_args__ = (
+        # Partial unique index: enforces uniqueness on (org_id, data_source_identifier)
+        # only when data_source_identifier IS NOT NULL.
+        Index(
+            "uq_metr_data_source_org_data_source_identifier",
+            "org_id",
+            "data_source_identifier",
+            unique=True,
+            postgresql_where=Column("data_source_identifier").isnot(None),
+        ),
+    )
 
 
 @generic_repr("id", "data_source_id", "group_id", "view_only")

--- a/tests/handlers/test_metr_data_sources.py
+++ b/tests/handlers/test_metr_data_sources.py
@@ -1,0 +1,243 @@
+from redash.models import DataSource, MetrDataSource, db
+from tests import BaseTestCase
+
+
+class TestMetrDataSourceIdentifierValidationResource(BaseTestCase):
+    def setUp(self):
+        super(TestMetrDataSourceIdentifierValidationResource, self).setUp()
+        self.admin = self.factory.create_admin()
+
+    def path(self, data_source):
+        return f"/api/data_sources/{data_source.id}/data_source_identifier/validate"
+
+    def test_validate_valid_data_source_identifier(self):
+        """Test that a valid data source identifier passes validation."""
+        data_source = self.factory.create_data_source()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": "remote-monitoring"},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.json["valid"])
+        self.assertEqual(rv.json["errors"], [])
+
+    def test_validate_empty_data_source_identifier(self):
+        """Test that an empty data source identifier fails validation."""
+        data_source = self.factory.create_data_source()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": ""},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertFalse(rv.json["valid"])
+        self.assertIn("Data source identifier is required", rv.json["errors"])
+
+    def test_validate_invalid_slug(self):
+        """Test that invalid slug format fails validation."""
+        data_source = self.factory.create_data_source()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": "Invalid Slug!"},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertFalse(rv.json["valid"])
+        self.assertIn("Not a valid slug", rv.json["errors"])
+
+    def test_validate_duplicate_data_source_identifier(self):
+        """Test that duplicate data source identifier fails validation."""
+        data_source1 = self.factory.create_data_source()
+        data_source2 = self.factory.create_data_source()
+
+        db.session.add(
+            MetrDataSource(
+                data_source_id=data_source1.id,
+                org_id=data_source1.org_id,
+                data_source_identifier="existing-id",
+            )
+        )
+        db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source2),
+            data={"data_source_identifier": "existing-id"},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertFalse(rv.json["valid"])
+        self.assertIn("Already used data source identifier", rv.json["errors"][0])
+
+    def test_validate_own_identifier_is_not_a_duplicate(self):
+        """Re-submitting a data source's own identifier is valid."""
+        data_source = self.factory.create_data_source()
+        db.session.add(
+            MetrDataSource(
+                data_source_id=data_source.id,
+                org_id=data_source.org_id,
+                data_source_identifier="mine",
+            )
+        )
+        db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": "mine"},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.json["valid"])
+
+    def test_validate_same_identifier_in_another_org(self):
+        """An identifier used in a different org does not collide."""
+        other_org = self.factory.create_org()
+        other_data_source = self.factory.create_data_source(org=other_org)
+        db.session.add(
+            MetrDataSource(
+                data_source_id=other_data_source.id,
+                org_id=other_org.id,
+                data_source_identifier="remote-monitoring",
+            )
+        )
+        db.session.commit()
+
+        data_source = self.factory.create_data_source()
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": "remote-monitoring"},
+            user=self.admin,
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.json["valid"])
+
+    def test_validate_requires_admin(self):
+        """A non-admin cannot stamp identifiers, so it cannot validate them either."""
+        data_source = self.factory.create_data_source()
+
+        rv = self.make_request(
+            "post",
+            self.path(data_source),
+            data={"data_source_identifier": "remote-monitoring"},
+            user=self.factory.create_user(),
+        )
+
+        self.assertEqual(rv.status_code, 403)
+
+
+class TestDataSourceIdentifierPersistence(BaseTestCase):
+    """The identifier is written through DataSourceResource.post."""
+
+    def setUp(self):
+        super(TestDataSourceIdentifierPersistence, self).setUp()
+        self.admin = self.factory.create_admin()
+        self.data_source = self.factory.data_source
+        self.path = f"/api/data_sources/{self.data_source.id}"
+
+    def post(self, **extra):
+        data = {
+            "name": self.data_source.name,
+            "type": "pg",
+            "options": {"dbname": "testdb"},
+        }
+        data.update(extra)
+        return self.make_request("post", self.path, data=data, user=self.admin)
+
+    def test_creates_the_sidecar_on_first_write(self):
+        rv = self.post(data_source_identifier="remote-monitoring")
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["data_source_identifier"], "remote-monitoring")
+
+        data_source = DataSource.query.get(self.data_source.id)
+        self.assertEqual(data_source.metr_data_source.data_source_identifier, "remote-monitoring")
+        self.assertEqual(data_source.metr_data_source.org_id, data_source.org_id)
+
+    def test_updates_an_existing_sidecar(self):
+        db.session.add(
+            MetrDataSource(
+                data_source=self.data_source,
+                org_id=self.data_source.org_id,
+                data_source_identifier="old-id",
+            )
+        )
+        db.session.commit()
+
+        rv = self.post(data_source_identifier="new-id")
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["data_source_identifier"], "new-id")
+        self.assertEqual(MetrDataSource.query.count(), 1)
+
+    def test_empty_identifier_is_stored_as_null(self):
+        """So the partial unique index does not treat "" as a used identifier."""
+        rv = self.post(data_source_identifier="")
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertIsNone(rv.json["data_source_identifier"])
+
+        data_source = DataSource.query.get(self.data_source.id)
+        self.assertIsNone(data_source.metr_data_source.data_source_identifier)
+
+    def test_omitting_the_field_leaves_the_identifier_alone(self):
+        db.session.add(
+            MetrDataSource(
+                data_source=self.data_source,
+                org_id=self.data_source.org_id,
+                data_source_identifier="untouched",
+            )
+        )
+        db.session.commit()
+
+        rv = self.post(name="Renamed")
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["data_source_identifier"], "untouched")
+
+
+class TestDataSourceSerialization(BaseTestCase):
+    def test_identifier_is_serialized_for_non_admins(self):
+        """The field is unconditional, not behind all=True: the frontend needs it."""
+        data_source = self.factory.data_source
+        db.session.add(
+            MetrDataSource(
+                data_source=data_source,
+                org_id=data_source.org_id,
+                data_source_identifier="remote-monitoring",
+            )
+        )
+        db.session.commit()
+
+        rv = self.make_request(
+            "get",
+            f"/api/data_sources/{data_source.id}",
+            user=self.factory.create_user(),
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["data_source_identifier"], "remote-monitoring")
+
+    def test_identifier_is_null_without_a_sidecar(self):
+        rv = self.make_request(
+            "get",
+            f"/api/data_sources/{self.factory.data_source.id}",
+            user=self.factory.create_admin(),
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertIsNone(rv.json["data_source_identifier"])

--- a/tests/models/test_metr_data_sources.py
+++ b/tests/models/test_metr_data_sources.py
@@ -1,0 +1,118 @@
+from sqlalchemy.exc import IntegrityError
+
+from redash.models import MetrDataSource, db
+from tests import BaseTestCase
+
+
+class MetrDataSourceTest(BaseTestCase):
+    """Test MetrDataSource model constraints and relationships."""
+
+    def test_prevents_duplicate_data_source_identifier_in_same_org(self):
+        """Duplicate data_source_identifier in same org raises IntegrityError."""
+        data_source1 = self.factory.create_data_source()
+        data_source2 = self.factory.create_data_source()
+        db.session.flush()
+
+        metr1 = MetrDataSource(
+            data_source_id=data_source1.id,
+            org_id=data_source1.org_id,
+            data_source_identifier="shared-slug",
+        )
+        db.session.add(metr1)
+        db.session.flush()
+
+        metr2 = MetrDataSource(
+            data_source_id=data_source2.id,
+            org_id=data_source2.org_id,
+            data_source_identifier="shared-slug",  # Same identifier, same org
+        )
+        db.session.add(metr2)
+
+        with self.assertRaises(IntegrityError):
+            db.session.flush()
+
+    def test_allows_multiple_null_data_source_identifiers_in_same_org(self):
+        """The unique index is partial, so unassigned identifiers do not collide."""
+        data_source1 = self.factory.create_data_source()
+        data_source2 = self.factory.create_data_source()
+        db.session.flush()
+
+        metr1 = MetrDataSource(data_source_id=data_source1.id, org_id=data_source1.org_id)
+        metr2 = MetrDataSource(data_source_id=data_source2.id, org_id=data_source2.org_id)
+        db.session.add_all([metr1, metr2])
+        db.session.flush()
+
+        self.assertIsNone(metr1.data_source_identifier)
+        self.assertIsNone(metr2.data_source_identifier)
+
+    def test_allows_same_data_source_identifier_in_different_orgs(self):
+        """Same data_source_identifier allowed across different orgs.
+
+        This is the whole point of the identifier: the template org and every
+        customer org carry the same one.
+        """
+        org1 = self.factory.create_org()
+        org2 = self.factory.create_org()
+
+        data_source1 = self.factory.create_data_source(org=org1)
+        data_source2 = self.factory.create_data_source(org=org2)
+        db.session.flush()
+
+        metr1 = MetrDataSource(
+            data_source_id=data_source1.id,
+            org_id=org1.id,
+            data_source_identifier="same-slug",
+        )
+        metr2 = MetrDataSource(
+            data_source_id=data_source2.id,
+            org_id=org2.id,
+            data_source_identifier="same-slug",  # Same identifier, different org
+        )
+        db.session.add_all([metr1, metr2])
+        db.session.flush()
+
+        self.assertEqual(metr1.data_source_identifier, "same-slug")
+        self.assertEqual(metr2.data_source_identifier, "same-slug")
+
+    def test_prevents_two_sidecars_for_the_same_data_source(self):
+        """data_source_id is unique: one sidecar per data source."""
+        data_source = self.factory.create_data_source()
+        db.session.flush()
+
+        db.session.add(MetrDataSource(data_source_id=data_source.id, org_id=data_source.org_id))
+        db.session.flush()
+
+        db.session.add(MetrDataSource(data_source_id=data_source.id, org_id=data_source.org_id))
+
+        with self.assertRaises(IntegrityError):
+            db.session.flush()
+
+    def test_deleting_the_data_source_deletes_the_sidecar(self):
+        """The relationship cascades, so no orphaned sidecar survives a delete."""
+        data_source = self.factory.create_data_source()
+        db.session.add(
+            MetrDataSource(
+                data_source=data_source,
+                org_id=data_source.org_id,
+                data_source_identifier="doomed",
+            )
+        )
+        db.session.commit()
+
+        data_source.delete()
+
+        self.assertIsNone(MetrDataSource.query.filter_by(data_source_identifier="doomed").first())
+
+    def test_backref_is_reachable_from_the_data_source(self):
+        """data_source.metr_data_source is the one-to-one backref."""
+        data_source = self.factory.create_data_source()
+        metr = MetrDataSource(
+            data_source=data_source,
+            org_id=data_source.org_id,
+            data_source_identifier="remote-monitoring",
+        )
+        db.session.add(metr)
+        db.session.commit()
+
+        self.assertEqual(data_source.metr_data_source, metr)
+        self.assertEqual(metr.data_source, data_source)


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4991

AI Disclaimer: I used Claude for this, because we already have two identifiers for dashboard and for queries so it was also easier to do make Claude do something similar.

# Summary

This is a pre-requisit to global redash.
Composed dashboards deployments need to find a customer org's copy of a template data source. Matching on name would break because we don't have standard names for data sources, so give each data source a standard identifier we can check against.

# Code Strategy


- Use `MetrDataSource` sidecar table, so the upstream table stays untouched and the pattern matches `MetrQuery` and `MetrDashboard`.
- Enforce uniqueness with a partial unique index on (org_id, data_source_identifier) where the identifier is not null, so unset data sources don't collide with each other.
- Route `data_source_identifier` through the existing `DataSourceResource` `POST` the same way `query_identifier` is routed to `MetrQuery`, and coerce "" to NULL so the partial index applies. The sidecar is created with `data_source=data_source` so the `backref` is populated before the commit.
- Validate format and uniqueness in a dedicated /validate endpoint instead of the main `POST`, keeping the pre-submit check out of the save path.
- Render it with `EditInPlace` on the data source edit page, editable only while unset: the identifier is what deployments match on, so changing it after the fact would silently break them.

Main places where this deliberately differs from how we do for query identifier and dashboard identifier: 

- Permissions: `require_admin` rather than `require_permission("edit_query"/"edit_dashboard")`, data sources are admin-only anyway.
- Usage of `DataSource.to_dict` since no serializer


# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Unit tests 
- [x] Manually (staging) https://dashboard.staging.metr.systems/staging/data_sources/3

<img width="1339" height="687" alt="Screenshot 2026-07-30 at 17 00 02" src="https://github.com/user-attachments/assets/f2e1e73f-0695-4f7c-a6d1-243d8599696c" />
