### PR TITLE
Feature/composed dashs deployment redeployment

### DIFF
--- a/redash_global/CLAUDE.md
+++ b/redash_global/CLAUDE.md
@@ -11,7 +11,10 @@ This file does not include everything yet.
 The metr style applies here too.
 
 - **pytest, not unittest.** No `unittest.TestCase`, no Redash `BaseTestCase`. Plain test functions; a bare `class TestX:` is fine purely for grouping. Native `assert`, never `self.assertEqual`.
-- **Fixtures, not module-level constants.** URLs, payloads, ids and objects belong in `@pytest.fixture`. Shared ones go in `tests/conftest.py`; single-file ones at the top of the test module.
+- **Fixtures, not module-level constants or helper functions.** URLs, payloads, ids and objects belong in `@pytest.fixture`, not a module-level constant or a plain helper function that builds and returns the data. Shared ones go in `tests/conftest.py`; single-file ones at the top of the test module.
+- **Fixtures return values directly, never a callable to invoke per test.** No `def fixture(): def create(): ...; return create` pattern. When a test needs several instances, define several concretely-named fixtures (e.g. `sub_dashboard`, `other_sub_dashboard`) rather than one fixture wrapping a factory closure — the reader should be able to trust a fixture's return value without opening its body.
+- **Avoid helper functions in tests.** Model-building and data-construction helpers belong in factories (`tests/factories.py`), not as functions in the test file. Query helpers belong in `deployment/utils.py` or as fixtures. This keeps test files focused on assertions, not setup boilerplate.
+- **Inline data used by only one test.** Don't extract a fixture (or helper function) for test data that only one test needs — inline it at that call site instead. Only pull it out into a fixture once a second test needs the same value.
 - **Check for an existing fixture first** — `tests/conftest.py` already gives you `redash_app`, `app`, `client`, `admin_client`, `admin`, `create_admin` and `factory`.
 - **Build models with the factory, never `db.session.add`.** Redash already has the factory pattern (`tests/factories.py`: a `ModelFactory` per model plus `Factory`'s `create_<model>` methods), so use it here too. `tests/factories.py` holds a `Factory` subclassing Redash's, which is what the `factory` fixture returns — add a `create_<model>` method there for each Redash Global model instead of putting them in Redash's own factories file, which keeps the main suite unaware of this app. `ModelFactory.create` commits, so no follow-up `db.session.commit()`.
 - **One `test_<module>.py` per source module** — `test_assignments.py` covers all of `views/assignments.py`. No per-view or per-function test files.
@@ -23,5 +26,6 @@ The metr style applies here too.
 ## Python patterns
 
 - **f-strings for interpolation**, in tests too — not `"...".format(x)` or `%`. Ruff's `UP032` isn't enabled here and upstream Redash is mixed, so this is convention, not lint-enforced. The one exception is logging: pass lazy args (`logger.info("got %s", x)`) so the string is only built when the record is emitted.
+- **No leading underscore on module-internal names**, even when a function or constant is only used within its own module (e.g. `validate_data_sources`, `widgets_with_query`, `DASHBOARD_LEVEL_MAPPING_TYPES` — not `_validate_data_sources`, `_DASHBOARD_LEVEL_MAPPING_TYPES`). Counter to normal Python/PEP8 convention, but a deliberate team style choice from code review — don't "fix" it back to underscore-prefixed private naming.
 - **Comments earn their place.** No comments restating what the code does; keep the ones that explain *why* a non-obvious choice was made (this module leans on those — see `routes.py`'s catch-all note and `tests/conftest.py`'s signal explanation).
 - Black + ruff via pre-commit, line length 119.

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from copy import deepcopy
 from datetime import datetime, timezone
 
 from redash.models import (
@@ -76,6 +77,7 @@ def deploy_to_target_org(composed_dashboard, target_org):
         record_deployment(composed_dashboard, target_org)
 
         db.session.commit()
+        execute_query_parameter_dependencies(dashboard)
         return DeploymentResult(composed_dashboard, target_org, error=None)
     except DeploymentError as error:
         db.session.rollback()
@@ -105,9 +107,8 @@ def get_or_copy_query(template_query, target_org, deploy_user, data_source_map, 
     if query_id_map is None:
         query_id_map = {}
 
-    resolve_query_dropdown_dependencies(
-        template_query.options or {}, target_org, deploy_user, data_source_map, query_id_map
-    )
+    options = deepcopy(template_query.options) if template_query.options else {}
+    resolve_query_dropdown_dependencies(options, target_org, deploy_user, data_source_map, query_id_map)
 
     identifier = template_query.data_source.metr_data_source.data_source_identifier
     target_data_source = data_source_map[identifier]
@@ -121,7 +122,7 @@ def get_or_copy_query(template_query, target_org, deploy_user, data_source_map, 
         query = metr_query.query
         query.name = template_query.name
         query.query_text = template_query.query_text
-        query.options = template_query.options
+        query.options = options
         query.data_source = target_data_source
         return query
 
@@ -135,7 +136,7 @@ def get_or_copy_query(template_query, target_org, deploy_user, data_source_map, 
         user=deploy_user,
         name=template_query.name,
         query_text=template_query.query_text,
-        options=template_query.options,
+        options=options,
     )
     db.session.add(query)
     db.session.flush()
@@ -169,7 +170,7 @@ def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source
     if query_id_map is None:
         query_id_map = {}
 
-    options = dict(template_widget.options or {})
+    options = deepcopy(template_widget.options) if template_widget.options else {}
     position = dict(options.get("position") or {})
     position["row"] = position.get("row", 0) + row_offset
     options["position"] = position
@@ -183,7 +184,7 @@ def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source
             type=template_widget.visualization.type,
             name=template_widget.visualization.name,
             description=template_widget.visualization.description,
-            options=template_widget.visualization.options,
+            options=deepcopy(template_widget.visualization.options) if template_widget.visualization.options else None,
         )
         db.session.add(visualization)
         db.session.flush()
@@ -280,6 +281,25 @@ def get_or_create_dashboard(composed_dashboard, target_org, deploy_user, allowed
 
     dashboard.metr_dashboard.allowed_widget_query_identifier = allowed_widgets_identifier
     return dashboard
+
+
+def execute_query_parameter_dependencies(dashboard):
+    executed_queries = set()
+
+    for widget in dashboard.widgets:
+        if widget.visualization_id:
+            query = widget.visualization.query_rel
+            for parameter in query.parameters:
+                if parameter.get("type") == "query":
+                    dep_query_id = parameter.get("queryId")
+                    if dep_query_id and dep_query_id not in executed_queries:
+                        dep_query = Query.query.get(dep_query_id)
+                        if dep_query and dep_query.data_source:
+                            try:
+                                dep_query.execute_async()
+                                executed_queries.add(dep_query_id)
+                            except Exception:
+                                pass
 
 
 def record_deployment(composed_dashboard, target_org):

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,7 +1,19 @@
 from collections import namedtuple
 from datetime import datetime, timezone
 
-from redash.models import Dashboard, DashboardGroup, Group, MetrDashboard, MetrDataSource, MetrQuery, Query, Visualization, Widget, db, metrWidget
+from redash.models import (
+    Dashboard,
+    DashboardGroup,
+    Group,
+    MetrDashboard,
+    MetrDataSource,
+    MetrQuery,
+    Query,
+    Visualization,
+    Widget,
+    db,
+    metrWidget,
+)
 from redash_global.deployment.exceptions import DeploymentError
 from redash_global.deployment.utils import widgets_with_query
 from redash_global.deployment.validations import validate_composed_dashboard
@@ -172,6 +184,7 @@ def delete_orphaned_visualizations(visualization_ids):
         db.session.flush()
         if not query.visualizations:
             db.session.delete(query)
+    db.session.flush()
 
 
 def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_source_map):

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,0 +1,75 @@
+from redash.models import MetrDataSource, MetrQuery, Query, db
+from redash_global.deployment.utils import widgets_with_query
+
+
+def get_target_data_sources(sub_dashboards, target_org):
+    identifiers = set()
+    for sub_dashboard in sub_dashboards:
+        for widget in widgets_with_query(sub_dashboard):
+            query = widget.visualization.query_rel
+            if query.data_source_id is not None:
+                metr_data_source = query.data_source.metr_data_source
+                if metr_data_source is not None:
+                    identifiers.add(metr_data_source.data_source_identifier)
+
+    return {
+        metr_data_source.data_source_identifier: metr_data_source.data_source
+        for metr_data_source in MetrDataSource.query.filter(
+            MetrDataSource.org_id == target_org.id,
+            MetrDataSource.data_source_identifier.in_(identifiers),
+        )
+    }
+
+
+def get_or_copy_query(template_query, target_org, deploy_user, data_source_map):
+    identifier = template_query.data_source.metr_data_source.data_source_identifier
+    target_data_source = data_source_map[identifier]
+
+    metr_query = (
+        db.session.query(MetrQuery)
+        .filter(MetrQuery.org_id == target_org.id, MetrQuery.template_query_id == template_query.id)
+        .first()
+    )
+    if metr_query:
+        query = metr_query.query
+        query.name = template_query.name
+        query.query_text = template_query.query_text
+        query.options = template_query.options
+        query.data_source = target_data_source
+        return query
+
+    # Bare constructor, not Query.create(...): Query.create always adds a "Table" TABLE
+    # visualization, which would collide with the visualization copy_widget/copy_allowed_widgets_query
+    # already builds. Query.fork (redash/models/__init__.py:798-820) avoids the same collision
+    # the same way.
+    query = Query(
+        org=target_org,
+        data_source=target_data_source,
+        user=deploy_user,
+        name=template_query.name,
+        query_text=template_query.query_text,
+        options=template_query.options,
+    )
+    db.session.add(query)
+    db.session.flush()
+    db.session.add(MetrQuery(query=query, org_id=target_org.id, template_query_id=template_query.id))
+    return query
+
+
+def copy_allowed_widgets_query(sub_dashboards, target_org, deploy_user, data_source_map):
+    metr_dashboard = sub_dashboards[0].metr_dashboard
+    identifier = metr_dashboard.allowed_widget_query_identifier if metr_dashboard else None
+    if identifier is None:
+        return None
+
+    template_org = sub_dashboards[0].org
+    template_query = (
+        db.session.query(Query)
+        .join(MetrQuery, MetrQuery.query_id == Query.id)
+        .filter(MetrQuery.org_id == template_org.id, MetrQuery.query_identifier == identifier)
+        .first()
+    )
+
+    query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+    query.metr_query.query_identifier = identifier
+    return identifier

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -22,6 +22,23 @@ from redash_global.models import ComposedDashboardDeployment, SubDashboardAssign
 DeploymentResult = namedtuple("DeploymentResult", ["composed_dashboard", "org", "error"])
 
 
+def resolve_query_dropdown_dependencies(options, target_org, deploy_user, data_source_map, query_id_map):
+    """Resolve query-based parameter dependencies before copying a query."""
+    for parameter in options.get("parameters", []):
+        if parameter.get("type") != "query":
+            continue
+
+        source_dep_id = parameter.get("queryId")
+        if source_dep_id in query_id_map:
+            parameter["queryId"] = query_id_map[source_dep_id]
+            continue
+
+        dependency_query = Query.query.get(source_dep_id)
+        copied_dependency = get_or_copy_query(dependency_query, target_org, deploy_user, data_source_map, query_id_map)
+        query_id_map[source_dep_id] = copied_dependency.id
+        parameter["queryId"] = copied_dependency.id
+
+
 def deploy_composed_dashboard(composed_dashboard, target_orgs):
     """Deploy/redeploy one composed dashboard to every target org.
 
@@ -50,11 +67,12 @@ def deploy_to_target_org(composed_dashboard, target_org):
 
         deploy_user = Group.members(target_org.admin_group.id).first()
         target_data_sources_map = get_target_data_sources(sub_dashboards, target_org)
+        query_id_map = {}
         allowed_widgets_identifier = copy_allowed_widgets_query(
-            sub_dashboards, target_org, deploy_user, target_data_sources_map
+            sub_dashboards, target_org, deploy_user, target_data_sources_map, query_id_map
         )
         dashboard = get_or_create_dashboard(composed_dashboard, target_org, deploy_user, allowed_widgets_identifier)
-        replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, target_data_sources_map)
+        replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, target_data_sources_map, query_id_map)
         record_deployment(composed_dashboard, target_org)
 
         db.session.commit()
@@ -83,7 +101,14 @@ def get_target_data_sources(sub_dashboards, target_org):
     }
 
 
-def get_or_copy_query(template_query, target_org, deploy_user, data_source_map):
+def get_or_copy_query(template_query, target_org, deploy_user, data_source_map, query_id_map=None):
+    if query_id_map is None:
+        query_id_map = {}
+
+    resolve_query_dropdown_dependencies(
+        template_query.options or {}, target_org, deploy_user, data_source_map, query_id_map
+    )
+
     identifier = template_query.data_source.metr_data_source.data_source_identifier
     target_data_source = data_source_map[identifier]
 
@@ -118,7 +143,10 @@ def get_or_copy_query(template_query, target_org, deploy_user, data_source_map):
     return query
 
 
-def copy_allowed_widgets_query(sub_dashboards, target_org, deploy_user, data_source_map):
+def copy_allowed_widgets_query(sub_dashboards, target_org, deploy_user, data_source_map, query_id_map=None):
+    if query_id_map is None:
+        query_id_map = {}
+
     metr_dashboard = sub_dashboards[0].metr_dashboard
     identifier = metr_dashboard.allowed_widget_query_identifier if metr_dashboard else None
     if identifier is None:
@@ -132,12 +160,15 @@ def copy_allowed_widgets_query(sub_dashboards, target_org, deploy_user, data_sou
         .first()
     )
 
-    query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+    query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map, query_id_map)
     query.metr_query.query_identifier = identifier
     return identifier
 
 
-def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset):
+def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset, query_id_map=None):
+    if query_id_map is None:
+        query_id_map = {}
+
     options = dict(template_widget.options or {})
     position = dict(options.get("position") or {})
     position["row"] = position.get("row", 0) + row_offset
@@ -146,7 +177,7 @@ def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source
     visualization = None
     if template_widget.visualization_id is not None:
         template_query = template_widget.visualization.query_rel
-        query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+        query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map, query_id_map)
         visualization = Visualization(
             query_rel=query,
             type=template_widget.visualization.type,
@@ -187,7 +218,10 @@ def delete_orphaned_visualizations(visualization_ids):
     db.session.flush()
 
 
-def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_source_map):
+def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_source_map, query_id_map=None):
+    if query_id_map is None:
+        query_id_map = {}
+
     old_widgets = dashboard.widgets.all()
     old_visualization_ids = {widget.visualization_id for widget in old_widgets if widget.visualization_id is not None}
     for widget in old_widgets:
@@ -198,7 +232,7 @@ def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_sou
     for sub_dashboard in sub_dashboards:
         sub_dashboard_height = 0
         for template_widget in sub_dashboard.widgets:
-            copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset)
+            copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset, query_id_map)
             position = (template_widget.options or {}).get("position") or {}
             sub_dashboard_height = max(sub_dashboard_height, position.get("row", 0) + position.get("sizeY", 0))
         row_offset += sub_dashboard_height

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,4 +1,4 @@
-from redash.models import MetrDataSource, MetrQuery, Query, db
+from redash.models import MetrDataSource, MetrQuery, Query, Visualization, Widget, db, metrWidget
 from redash_global.deployment.utils import widgets_with_query
 
 
@@ -73,3 +73,73 @@ def copy_allowed_widgets_query(sub_dashboards, target_org, deploy_user, data_sou
     query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
     query.metr_query.query_identifier = identifier
     return identifier
+
+
+def copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset):
+    options = dict(template_widget.options or {})
+    position = dict(options.get("position") or {})
+    position["row"] = position.get("row", 0) + row_offset
+    options["position"] = position
+
+    visualization = None
+    if template_widget.visualization_id is not None:
+        template_query = template_widget.visualization.query_rel
+        query = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+        visualization = Visualization(
+            query_rel=query,
+            type=template_widget.visualization.type,
+            name=template_widget.visualization.name,
+            description=template_widget.visualization.description,
+            options=template_widget.visualization.options,
+        )
+        db.session.add(visualization)
+        db.session.flush()
+
+    widget = Widget(
+        dashboard=dashboard,
+        visualization=visualization,
+        text=template_widget.text,
+        width=template_widget.width,
+        options=options,
+    )
+    db.session.add(widget)
+    db.session.flush()
+
+    template_metr_widget = template_widget.metr_widget
+    if template_metr_widget and template_metr_widget.tags:
+        db.session.add(metrWidget(widget=widget, tags=list(template_metr_widget.tags)))
+
+    return widget
+
+
+def delete_orphaned_visualizations(visualization_ids):
+    for visualization_id in visualization_ids:
+        visualization = Visualization.query.get(visualization_id)
+        if visualization is None or Widget.query.filter_by(visualization_id=visualization_id).first() is not None:
+            continue
+        query = visualization.query_rel
+        db.session.delete(visualization)
+        db.session.flush()
+        if not query.visualizations:
+            db.session.delete(query)
+
+
+def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_source_map):
+    old_widgets = dashboard.widgets.all()
+    old_visualization_ids = {widget.visualization_id for widget in old_widgets if widget.visualization_id is not None}
+    for widget in old_widgets:
+        db.session.delete(widget)
+    db.session.flush()
+
+    row_offset = 0
+    for sub_dashboard in sub_dashboards:
+        sub_dashboard_height = 0
+        for template_widget in sub_dashboard.widgets:
+            copy_widget(template_widget, dashboard, target_org, deploy_user, data_source_map, row_offset)
+            position = (template_widget.options or {}).get("position") or {}
+            sub_dashboard_height = max(sub_dashboard_height, position.get("row", 0) + position.get("sizeY", 0))
+        row_offset += sub_dashboard_height
+
+    # Anything from the old widget set that step above didn't recreate (the template dropped
+    # that widget) is now genuinely orphaned.
+    delete_orphaned_visualizations(old_visualization_ids)

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,8 +1,55 @@
+from collections import namedtuple
 from datetime import datetime, timezone
 
 from redash.models import Dashboard, DashboardGroup, Group, MetrDashboard, MetrDataSource, MetrQuery, Query, Visualization, Widget, db, metrWidget
+from redash_global.deployment.exceptions import DeploymentError
 from redash_global.deployment.utils import widgets_with_query
-from redash_global.models import ComposedDashboardDeployment
+from redash_global.deployment.validations import validate_composed_dashboard
+from redash_global.models import ComposedDashboardDeployment, SubDashboardAssignment
+
+DeploymentResult = namedtuple("DeploymentResult", ["composed_dashboard", "org", "error"])
+
+
+def deploy_composed_dashboard(composed_dashboard, target_orgs):
+    """Deploy/redeploy one composed dashboard to every target org.
+
+    Each org is independent: one failing does not affect the rest, or roll back an org that
+    already succeeded.
+    """
+    return [deploy_to_target_org(composed_dashboard, target_org) for target_org in target_orgs]
+
+
+def ordered_org_assigned_subdashboard(composed_dashboard, target_org):
+    """The composed dashboard's entries, filtered to those assigned to target_org, in order_index order."""
+    assigned_ids = {
+        assignment.dashboard_id for assignment in SubDashboardAssignment.query.filter_by(organization_id=target_org.id)
+    }
+    return [
+        Dashboard.query.get(entry.template_dashboard_id)
+        for entry in composed_dashboard.entries
+        if entry.template_dashboard_id in assigned_ids
+    ]
+
+
+def deploy_to_target_org(composed_dashboard, target_org):
+    try:
+        sub_dashboards = ordered_org_assigned_subdashboard(composed_dashboard, target_org)
+        validate_composed_dashboard(sub_dashboards, target_org)
+
+        deploy_user = Group.members(target_org.admin_group.id).first()
+        target_data_sources_map = get_target_data_sources(sub_dashboards, target_org)
+        allowed_widgets_identifier = copy_allowed_widgets_query(
+            sub_dashboards, target_org, deploy_user, target_data_sources_map
+        )
+        dashboard = get_or_create_dashboard(composed_dashboard, target_org, deploy_user, allowed_widgets_identifier)
+        replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, target_data_sources_map)
+        record_deployment(composed_dashboard, target_org)
+
+        db.session.commit()
+        return DeploymentResult(composed_dashboard, target_org, error=None)
+    except DeploymentError as error:
+        db.session.rollback()
+        return DeploymentResult(composed_dashboard, target_org, error=error)
 
 
 def get_target_data_sources(sub_dashboards, target_org):

--- a/redash_global/deployment/deploy.py
+++ b/redash_global/deployment/deploy.py
@@ -1,5 +1,8 @@
-from redash.models import MetrDataSource, MetrQuery, Query, Visualization, Widget, db, metrWidget
+from datetime import datetime, timezone
+
+from redash.models import Dashboard, DashboardGroup, Group, MetrDashboard, MetrDataSource, MetrQuery, Query, Visualization, Widget, db, metrWidget
 from redash_global.deployment.utils import widgets_with_query
+from redash_global.models import ComposedDashboardDeployment
 
 
 def get_target_data_sources(sub_dashboards, target_org):
@@ -143,3 +146,58 @@ def replace_widgets(dashboard, sub_dashboards, target_org, deploy_user, data_sou
     # Anything from the old widget set that step above didn't recreate (the template dropped
     # that widget) is now genuinely orphaned.
     delete_orphaned_visualizations(old_visualization_ids)
+
+
+def create_dashboard(composed_dashboard, target_org, deploy_user):
+    dashboard = Dashboard(
+        name=composed_dashboard.name,
+        org=target_org,
+        user=deploy_user,
+        is_draft=False,
+        layout=[],
+    )
+    db.session.add(dashboard)
+    db.session.flush()
+    db.session.add(DashboardGroup(dashboard=dashboard, group=target_org.default_group))
+    db.session.add(
+        MetrDashboard(
+            dashboard=dashboard,
+            org_id=target_org.id,
+            url_identifier=composed_dashboard.url_identifier,
+        )
+    )
+    db.session.flush()
+    return dashboard
+
+
+def get_or_create_dashboard(composed_dashboard, target_org, deploy_user, allowed_widgets_identifier):
+    dashboard = (
+        Dashboard.query.join(MetrDashboard, Dashboard.id == MetrDashboard.dashboard_id)
+        .filter(
+            MetrDashboard.url_identifier == composed_dashboard.url_identifier,
+            MetrDashboard.org_id == target_org.id,
+        )
+        .first()
+    )
+    if dashboard:
+        dashboard.name = composed_dashboard.name
+    else:
+        dashboard = create_dashboard(composed_dashboard, target_org, deploy_user)
+
+    dashboard.metr_dashboard.allowed_widget_query_identifier = allowed_widgets_identifier
+    return dashboard
+
+
+def record_deployment(composed_dashboard, target_org):
+    deployment = ComposedDashboardDeployment.query.filter_by(
+        composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
+    ).first()
+    if deployment is None:
+        deployment = ComposedDashboardDeployment(
+            composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
+        )
+        db.session.add(deployment)
+    # A plain Python-side timestamp, not func.now(): this app's session uses
+    # expire_on_commit=False, so a func.now() value would stay an unresolved SQL construct on
+    # this attribute after commit instead of refreshing to the real value.
+    deployment.last_deployed_at = datetime.now(timezone.utc)

--- a/redash_global/deployment/exceptions.py
+++ b/redash_global/deployment/exceptions.py
@@ -8,3 +8,7 @@ class DataSourceError(DeploymentError):
 
 class AllowedWidgetsQueryError(DeploymentError):
     pass
+
+
+class ParameterError(DeploymentError):
+    pass

--- a/redash_global/deployment/exceptions.py
+++ b/redash_global/deployment/exceptions.py
@@ -1,0 +1,6 @@
+class DeploymentError(Exception):
+    pass
+
+
+class DataSourceError(DeploymentError):
+    pass

--- a/redash_global/deployment/exceptions.py
+++ b/redash_global/deployment/exceptions.py
@@ -4,3 +4,7 @@ class DeploymentError(Exception):
 
 class DataSourceError(DeploymentError):
     pass
+
+
+class AllowedWidgetsQueryError(DeploymentError):
+    pass

--- a/redash_global/deployment/exceptions.py
+++ b/redash_global/deployment/exceptions.py
@@ -2,6 +2,12 @@ class DeploymentError(Exception):
     pass
 
 
+class DeploymentErrorGroup(DeploymentError):
+    def __init__(self, message, errors):
+        super().__init__(message)
+        self.errors = errors
+
+
 class DataSourceError(DeploymentError):
     pass
 

--- a/redash_global/deployment/utils.py
+++ b/redash_global/deployment/utils.py
@@ -1,0 +1,3 @@
+def widgets_with_query(sub_dashboard):
+    """Widgets that have a visualization, and therefore a query. Excludes text-box widgets."""
+    return [widget for widget in sub_dashboard.widgets if widget.visualization_id is not None]

--- a/redash_global/deployment/validations.py
+++ b/redash_global/deployment/validations.py
@@ -1,6 +1,8 @@
 from redash.models import MetrDataSource
-from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError
+from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError, ParameterError
 from redash_global.deployment.utils import widgets_with_query
+
+DASHBOARD_LEVEL_MAPPING_TYPES = {"dashboard-level", "fixed-from-url"}
 
 
 def validate_data_sources(sub_dashboards, target_org):
@@ -82,3 +84,44 @@ def validate_allowed_widgets_query(sub_dashboards):
             )
         ]
     return []
+
+
+def dashboard_level_params(widget):
+    """Yield (name, type) for each of *widget*'s dashboard-level
+    and fixed-from-url parameter mappings.
+    """
+    query = widget.visualization.query_rel
+    mappings = (widget.options or {}).get("parameterMappings") or {}
+    for param in query.parameters:
+        mapping = mappings.get(param["name"])
+        if mapping and mapping.get("type") in DASHBOARD_LEVEL_MAPPING_TYPES:
+            yield mapping.get("mapTo") or param["name"], param.get("type")
+
+
+def validate_parameters(sub_dashboards):
+    """A dashboard-level parameter name must always map to exactly one type.
+
+    "Dashboard-level" also covers "fixed-from-url" mappings. Sub-dashboards don't need
+    identical parameter sets - a parameter used by only some of them still becomes a
+    composed-dashboard parameter. Widget-level and static-value mappings are local to their
+    widget and need no cross-dashboard check.
+
+    We report an error when:
+    - the same dashboard-level parameter name maps to different types across sub-dashboards
+    """
+    errors = []
+    param_types = {}
+    for sub_dashboard in sub_dashboards:
+        for widget in widgets_with_query(sub_dashboard):
+            for name, param_type in dashboard_level_params(widget):
+                existing_type = param_types.get(name)
+                if existing_type is not None and existing_type != param_type:
+                    errors.append(
+                        ParameterError(
+                            f"Dashboard-level parameter '{name}' is type {existing_type!r} on one "
+                            f"sub-dashboard and {param_type!r} on another"
+                        )
+                    )
+                else:
+                    param_types[name] = param_type
+    return errors

--- a/redash_global/deployment/validations.py
+++ b/redash_global/deployment/validations.py
@@ -1,8 +1,27 @@
 from redash.models import MetrDataSource
-from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError, ParameterError
+from redash_global.deployment.exceptions import (
+    AllowedWidgetsQueryError,
+    DataSourceError,
+    DeploymentErrorGroup,
+    ParameterError,
+)
 from redash_global.deployment.utils import widgets_with_query
 
 DASHBOARD_LEVEL_MAPPING_TYPES = {"dashboard-level", "fixed-from-url"}
+
+
+def validate_composed_dashboard(sub_dashboards, target_org):
+    errors = [
+        *validate_data_sources(sub_dashboards, target_org),
+        *validate_allowed_widgets_query(sub_dashboards),
+        *validate_parameters(sub_dashboards),
+    ]
+
+    if errors:
+        raise DeploymentErrorGroup(
+            "Composed dashboard validation failed",
+            errors,
+        )
 
 
 def validate_data_sources(sub_dashboards, target_org):

--- a/redash_global/deployment/validations.py
+++ b/redash_global/deployment/validations.py
@@ -1,0 +1,63 @@
+from redash.models import MetrDataSource
+from redash_global.deployment.exceptions import DataSourceError
+from redash_global.deployment.utils import widgets_with_query
+
+
+def validate_data_sources(sub_dashboards, target_org):
+    """Every data source a sub-dashboard's widgets use must also exist in the target org.
+    We match on MetrDataSource.data_source_identifier.
+
+    We report an error when:
+    - the query's data source was deleted (DataSource.delete() nulls data_source_id instead of
+      leaving a dangling FK)
+    - the data source has no identifier
+    - the target org has no data source with that identifier
+    """
+    errors = []
+    identifiers = set()
+    for sub_dashboard in sub_dashboards:
+        for widget in widgets_with_query(sub_dashboard):
+            # data source has been deleted
+            query = widget.visualization.query_rel
+            if query.data_source_id is None:
+                # Data sources can be deleted and related objects receive value NONE
+                # https://github.com/metr-systems/redash/blob/14993943bbd3a4f2ae0ce55d32b6773363bfd8f0/redash/models/__init__.py#L197
+                errors.append(
+                    DataSourceError(
+                        f"Query {query.id} ('{query.name}') on sub-dashboard {sub_dashboard.id} "
+                        f"('{sub_dashboard.name}') has no data source"
+                    )
+                )
+                continue
+
+            # data source has no identifier
+            metr_data_source = query.data_source.metr_data_source
+            if metr_data_source is None or metr_data_source.data_source_identifier is None:
+                errors.append(
+                    DataSourceError(
+                        f"Data source {query.data_source_id} used by query {query.id} ('{query.name}') "
+                        f"on sub-dashboard {sub_dashboard.id} ('{sub_dashboard.name}') has no identifier"
+                    )
+                )
+                continue
+            identifiers.add(metr_data_source.data_source_identifier)
+
+    if not identifiers:
+        return errors
+
+    # target org has no data source for one or more identifiers
+    existing_identifiers = {
+        row.data_source_identifier
+        for row in MetrDataSource.query.filter(
+            MetrDataSource.org_id == target_org.id,
+            MetrDataSource.data_source_identifier.in_(identifiers),
+        )
+    }
+    missing_identifiers = identifiers - existing_identifiers
+    if missing_identifiers:
+        errors.append(
+            DataSourceError(
+                f"Organization {target_org.id} has no data source for identifiers: {sorted(missing_identifiers)}"
+            )
+        )
+    return errors

--- a/redash_global/deployment/validations.py
+++ b/redash_global/deployment/validations.py
@@ -1,5 +1,5 @@
 from redash.models import MetrDataSource
-from redash_global.deployment.exceptions import DataSourceError
+from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError
 from redash_global.deployment.utils import widgets_with_query
 
 
@@ -61,3 +61,24 @@ def validate_data_sources(sub_dashboards, target_org):
             )
         )
     return errors
+
+
+def validate_allowed_widgets_query(sub_dashboards):
+    """All sub-dashboards must reference the same allowed-widgets query, if any.
+    No allowed-widgets query at all is also valid.
+
+    We report an error when:
+    - sub-dashboards reference more than one distinct allowed-widgets query
+    """
+    identifiers = {
+        sub_dashboard.metr_dashboard.allowed_widget_query_identifier
+        for sub_dashboard in sub_dashboards
+        if sub_dashboard.metr_dashboard and sub_dashboard.metr_dashboard.allowed_widget_query_identifier
+    }
+    if len(identifiers) > 1:
+        return [
+            AllowedWidgetsQueryError(
+                f"Sub-dashboards reference different allowed-widgets queries: {sorted(identifiers)}"
+            )
+        ]
+    return []

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -14,6 +14,7 @@ from redash_global.deployment.deploy import (
     ordered_org_assigned_subdashboard,
     record_deployment,
     replace_widgets,
+    resolve_query_dropdown_dependencies,
 )
 from redash_global.models import ComposedDashboardDeployment
 
@@ -65,6 +66,71 @@ class TestGetTargetDataSources:
         result = get_target_data_sources([sub_dashboard], target_org)
 
         assert result == {}
+
+
+class TestResolveQueryDropdownDependencies:
+    def test_ignores_parameters_without_query_type(self, factory, target_org):
+        deploy_user = factory.create_user(org=target_org)
+        data_source_map = {}
+        query_id_map = {}
+
+        query_options = {
+            "parameters": [
+                {"name": "param1", "type": "text"},
+                {"name": "param2", "type": "date"},
+            ]
+        }
+
+        resolve_query_dropdown_dependencies(query_options, target_org, deploy_user, data_source_map, query_id_map)
+
+        assert query_id_map == {}
+
+    def test_updates_existing_query_id_in_map(self, factory, target_org):
+        deploy_user = factory.create_user(org=target_org)
+        data_source_map = {}
+        query_id_map = {123: 456}
+
+        query_options = {
+            "parameters": [
+                {"name": "param1", "type": "query", "queryId": 123},
+            ]
+        }
+
+        resolve_query_dropdown_dependencies(query_options, target_org, deploy_user, data_source_map, query_id_map)
+
+        assert query_options["parameters"][0]["queryId"] == 456
+
+    def test_copies_missing_query_dependency(self, factory, target_org):
+        template_org = factory.create_org()
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+        query_id_map = {}
+
+        query_options = {
+            "parameters": [
+                {"name": "param1", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        resolve_query_dropdown_dependencies(query_options, target_org, deploy_user, data_source_map, query_id_map)
+
+        assert query_options["parameters"][0]["queryId"] != dep_query.id
+        copied_query_id = query_options["parameters"][0]["queryId"]
+        copied_query = db.session.query(MetrQuery).filter_by(
+            template_query_id=dep_query.id, org_id=target_org.id
+        ).one()
+        assert copied_query.query_id == copied_query_id
 
 
 class TestGetOrCopyQuery:
@@ -120,6 +186,78 @@ class TestGetOrCopyQuery:
 
         assert second_result.id == first_id
         assert second_result.query_text == "SELECT 2"
+
+    def test_copies_query_with_query_based_parameter(self, factory, sub_dashboard, target_org):
+        template_org = sub_dashboard.org
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        template_query = widget.visualization.query_rel
+        template_query.data_source = template_ds
+        template_query.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        assert result.options["parameters"][0]["queryId"] != dep_query.id
+        assert result.options["parameters"][0]["type"] == "query"
+
+    def test_reuses_copied_query_for_shared_parameter_dependency(self, factory, target_org):
+        template_org = factory.create_org()
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+        query_id_map = {}
+
+        query1_dashboard = factory.create_dashboard(org=template_org)
+        query1_widget = factory.create_widget(dashboard=query1_dashboard)
+        query1 = query1_widget.visualization.query_rel
+        query1.data_source = template_ds
+        query1.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        query2_dashboard = factory.create_dashboard(org=template_org)
+        query2_widget = factory.create_widget(dashboard=query2_dashboard)
+        query2 = query2_widget.visualization.query_rel
+        query2.data_source = template_ds
+        query2.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        result1 = get_or_copy_query(query1, target_org, deploy_user, data_source_map, query_id_map)
+        result2 = get_or_copy_query(query2, target_org, deploy_user, data_source_map, query_id_map)
+
+        assert result1.options["parameters"][0]["queryId"] == result2.options["parameters"][0]["queryId"]
 
 
 class TestCopyAllowedWidgetsQuery:
@@ -204,6 +342,38 @@ class TestCopyWidget:
 
         assert result.text == "hello"
         assert result.visualization_id is None
+
+    def test_copies_widget_with_query_based_parameter(self, factory, sub_dashboard, target_org):
+        template_org = sub_dashboard.org
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = widget.visualization.query_rel
+        query.data_source = template_ds
+        query.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        deploy_user = factory.create_user(org=target_org)
+
+        result = copy_widget(widget, target_dashboard, target_org, deploy_user, data_source_map, row_offset=0)
+
+        assert result.visualization.query_rel.options["parameters"][0]["queryId"] != dep_query.id
 
 
 class TestDeleteOrphanedVisualizations:
@@ -450,6 +620,52 @@ class TestDeployToTargetOrg:
         result = deploy_to_target_org(composed_dashboard, target_org)
 
         assert result.error is not None
+
+    def test_deploys_dashboard_with_query_based_parameters(self, factory, sub_dashboard, target_org):
+        template_org = sub_dashboard.org
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = widget.visualization.query_rel
+        query.data_source = template_ds
+        query.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub_dashboard.id
+        )
+        factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard.id, organization_id=target_org.id)
+        factory.create_admin(org=target_org)
+
+        result = deploy_to_target_org(composed_dashboard, target_org)
+
+        assert result.error is None
+        deployed = (
+            Dashboard.query.join(MetrDashboard, Dashboard.id == MetrDashboard.dashboard_id)
+            .filter(
+                MetrDashboard.url_identifier == composed_dashboard.url_identifier,
+                MetrDashboard.org_id == target_org.id,
+            )
+            .one()
+        )
+        deployed_query = deployed.widgets[0].visualization.query_rel
+        assert deployed_query.options["parameters"][0]["type"] == "query"
+        assert deployed_query.options["parameters"][0]["queryId"] != dep_query.id
 
 
 class TestDeployComposedDashboard:

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -1,10 +1,13 @@
 import pytest
 
-from redash.models import MetrQuery
+from redash.models import MetrQuery, Visualization, Widget
 from redash_global.deployment.deploy import (
     copy_allowed_widgets_query,
+    copy_widget,
+    delete_orphaned_visualizations,
     get_or_copy_query,
     get_target_data_sources,
+    replace_widgets,
 )
 
 
@@ -140,3 +143,130 @@ class TestCopyAllowedWidgetsQuery:
         result = copy_allowed_widgets_query([sub_dashboard], target_org, deploy_user, data_source_map)
 
         assert result == "allowed-widgets"
+
+
+class TestCopyWidget:
+    def test_copies_widget_with_visualization(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = widget.visualization.query_rel
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        deploy_user = factory.create_user(org=target_org)
+
+        result = copy_widget(widget, target_dashboard, target_org, deploy_user, data_source_map, row_offset=0)
+
+        assert result.dashboard_id == target_dashboard.id
+        assert result.visualization_id is not None
+        assert result.options["position"]["row"] == 0
+
+    def test_offsets_widget_row_position(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 5, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = widget.visualization.query_rel
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        deploy_user = factory.create_user(org=target_org)
+
+        result = copy_widget(widget, target_dashboard, target_org, deploy_user, data_source_map, row_offset=10)
+
+        assert result.options["position"]["row"] == 15
+
+    def test_copies_text_only_widget(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(
+            dashboard=sub_dashboard,
+            visualization=None,
+            text="hello",
+            options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}},
+        )
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        deploy_user = factory.create_user(org=target_org)
+
+        result = copy_widget(widget, target_dashboard, target_org, deploy_user, {}, row_offset=0)
+
+        assert result.text == "hello"
+        assert result.visualization_id is None
+
+
+class TestDeleteOrphanedVisualizations:
+    def test_deletes_visualization_with_no_widgets(self, factory):
+        visualization = factory.create_visualization()
+
+        delete_orphaned_visualizations([visualization.id])
+
+        assert Visualization.query.get(visualization.id) is None
+
+    def test_does_not_delete_visualization_with_widgets(self, factory, sub_dashboard):
+        factory.create_widget(dashboard=sub_dashboard)
+        visualization = sub_dashboard.widgets[0].visualization
+
+        delete_orphaned_visualizations([visualization.id])
+
+        assert Visualization.query.get(visualization.id) is not None
+
+    def test_deletes_query_when_last_visualization_removed(self, factory):
+        visualization = factory.create_visualization()
+        query_id = visualization.query_rel.id
+
+        delete_orphaned_visualizations([visualization.id])
+
+        from redash.models import Query
+        assert Query.query.get(query_id) is None
+
+
+class TestReplaceWidgets:
+    def test_removes_old_widgets_and_copies_new_ones(self, factory, sub_dashboard, target_org):
+        template_widget = factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = template_widget.visualization.query_rel
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        old_widget = factory.create_widget(dashboard=target_dashboard)
+
+        deploy_user = factory.create_user(org=target_org)
+
+        replace_widgets(target_dashboard, [sub_dashboard], target_org, deploy_user, data_source_map)
+
+        assert target_dashboard.widgets.count() == 1
+        assert target_dashboard.widgets[0].id != old_widget.id
+
+    def test_offsets_rows_across_multiple_sub_dashboards(self, factory, sub_dashboard, target_org):
+        factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 2}}
+        )
+        other_sub_dashboard = factory.create_dashboard()
+        factory.create_widget(
+            dashboard=other_sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 3}}
+        )
+
+        for widget in sub_dashboard.widgets + other_sub_dashboard.widgets:
+            query = widget.visualization.query_rel
+            factory.create_metr_data_source_for(query.data_source, "postgres")
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        deploy_user = factory.create_user(org=target_org)
+
+        replace_widgets(target_dashboard, [sub_dashboard, other_sub_dashboard], target_org, deploy_user, data_source_map)
+
+        rows = sorted(w.options["position"]["row"] for w in target_dashboard.widgets.all())
+        assert rows == [0, 2]

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -1,0 +1,142 @@
+import pytest
+
+from redash.models import MetrQuery
+from redash_global.deployment.deploy import (
+    copy_allowed_widgets_query,
+    get_or_copy_query,
+    get_target_data_sources,
+)
+
+
+@pytest.fixture
+def sub_dashboard(factory):
+    return factory.create_dashboard()
+
+
+@pytest.fixture
+def target_org(factory):
+    return factory.create_org()
+
+
+class TestGetTargetDataSources:
+    def test_returns_empty_dict_when_no_widgets_have_queries(self, factory, sub_dashboard, target_org):
+        factory.create_widget(dashboard=sub_dashboard, visualization=None, text="text only")
+
+        result = get_target_data_sources([sub_dashboard], target_org)
+
+        assert result == {}
+
+    def test_returns_matching_data_sources_by_identifier(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        template_ds = widget.visualization.query_rel.data_source
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+
+        result = get_target_data_sources([sub_dashboard], target_org)
+
+        assert result == {"postgres": target_ds}
+
+    def test_ignores_data_sources_without_identifiers(self, factory, sub_dashboard, target_org):
+        factory.create_widget(dashboard=sub_dashboard)
+
+        result = get_target_data_sources([sub_dashboard], target_org)
+
+        assert result == {}
+
+    def test_returns_only_matching_identifiers(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        factory.create_metr_data_source_for(widget.visualization.query_rel.data_source, "postgres")
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "mysql")
+
+        result = get_target_data_sources([sub_dashboard], target_org)
+
+        assert result == {}
+
+
+class TestGetOrCopyQuery:
+    def test_creates_new_query_when_none_exists(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        template_query = widget.visualization.query_rel
+        factory.create_metr_data_source_for(template_query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        assert result.org_id == target_org.id
+        assert result.data_source_id == target_ds.id
+        assert result.name == template_query.name
+        assert result.query_text == template_query.query_text
+
+    def test_creates_metr_query_tracking_template_query(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        template_query = widget.visualization.query_rel
+        factory.create_metr_data_source_for(template_query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        metr_query = MetrQuery.query.filter_by(query_id=result.id).one()
+        assert metr_query.template_query_id == template_query.id
+        assert metr_query.org_id == target_org.id
+
+    def test_updates_existing_query_in_place(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        template_query = widget.visualization.query_rel
+        factory.create_metr_data_source_for(template_query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        first_result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+        first_id = first_result.id
+
+        template_query.query_text = "SELECT 2"
+
+        second_result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        assert second_result.id == first_id
+        assert second_result.query_text == "SELECT 2"
+
+
+class TestCopyAllowedWidgetsQuery:
+    def test_returns_none_when_no_allowed_widgets_query(self, factory, sub_dashboard, target_org):
+        factory.create_widget(dashboard=sub_dashboard)
+        deploy_user = factory.create_user(org=target_org)
+        data_source_map = {}
+
+        result = copy_allowed_widgets_query([sub_dashboard], target_org, deploy_user, data_source_map)
+
+        assert result is None
+
+    def test_returns_identifier_when_query_copied(self, factory, sub_dashboard, target_org):
+        query = factory.create_query()
+        factory.create_metr_query(query=query, query_identifier="allowed-widgets")
+        factory.create_metr_dashboard(
+            dashboard_id=sub_dashboard.id,
+            org_id=sub_dashboard.org_id,
+            allowed_widget_query_identifier="allowed-widgets",
+        )
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = copy_allowed_widgets_query([sub_dashboard], target_org, deploy_user, data_source_map)
+
+        assert result == "allowed-widgets"

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from redash.models import Dashboard, MetrDashboard, MetrQuery, Visualization, Widget
+from redash.models import Dashboard, MetrDashboard, MetrQuery, Visualization, db
 from redash_global.deployment.deploy import (
     copy_allowed_widgets_query,
     copy_widget,
@@ -97,7 +97,7 @@ class TestGetOrCopyQuery:
 
         result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
 
-        metr_query = MetrQuery.query.filter_by(query_id=result.id).one()
+        metr_query = db.session.query(MetrQuery).filter_by(query_id=result.id).one()
         assert metr_query.template_query_id == template_query.id
         assert metr_query.org_id == target_org.id
 
@@ -134,7 +134,7 @@ class TestCopyAllowedWidgetsQuery:
 
     def test_returns_identifier_when_query_copied(self, factory, sub_dashboard, target_org):
         query = factory.create_query()
-        factory.create_metr_query(query=query, query_identifier="allowed-widgets")
+        factory.create_metr_query(query=query, org_id=query.org_id, query_identifier="allowed-widgets")
         factory.create_metr_dashboard(
             dashboard_id=sub_dashboard.id,
             org_id=sub_dashboard.org_id,
@@ -229,6 +229,7 @@ class TestDeleteOrphanedVisualizations:
         delete_orphaned_visualizations([visualization.id])
 
         from redash.models import Query
+
         assert Query.query.get(query_id) is None
 
 
@@ -262,9 +263,12 @@ class TestReplaceWidgets:
             dashboard=other_sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 3}}
         )
 
-        for widget in sub_dashboard.widgets + other_sub_dashboard.widgets:
+        data_sources = set()
+        for widget in list(sub_dashboard.widgets) + list(other_sub_dashboard.widgets):
             query = widget.visualization.query_rel
-            factory.create_metr_data_source_for(query.data_source, "postgres")
+            if query.data_source_id not in data_sources:
+                factory.create_metr_data_source_for(query.data_source, "postgres")
+                data_sources.add(query.data_source_id)
 
         target_ds = factory.create_data_source(org=target_org)
         factory.create_metr_data_source_for(target_ds, "postgres")
@@ -273,7 +277,9 @@ class TestReplaceWidgets:
         target_dashboard = factory.create_dashboard(org=target_org)
         deploy_user = factory.create_user(org=target_org)
 
-        replace_widgets(target_dashboard, [sub_dashboard, other_sub_dashboard], target_org, deploy_user, data_source_map)
+        replace_widgets(
+            target_dashboard, [sub_dashboard, other_sub_dashboard], target_org, deploy_user, data_source_map
+        )
 
         rows = sorted(w.options["position"]["row"] for w in target_dashboard.widgets.all())
         assert rows == [0, 2]
@@ -371,7 +377,10 @@ class TestRecordDeployment:
 class TestOrderedOrgAssignedSubdashboard:
     def test_returns_empty_list_when_no_assignments(self, factory, target_org):
         sub_dashboard = factory.create_dashboard()
-        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub_dashboard.id
+        )
 
         result = ordered_org_assigned_subdashboard(composed_dashboard, target_org)
 
@@ -380,9 +389,19 @@ class TestOrderedOrgAssignedSubdashboard:
     def test_returns_assigned_dashboards_in_order(self, factory, target_org):
         sub_dashboard_1 = factory.create_dashboard()
         sub_dashboard_2 = factory.create_dashboard()
-        factory.create_sub_dashboard_assignment_for(sub_dashboard_1, target_org)
-        factory.create_sub_dashboard_assignment_for(sub_dashboard_2, target_org)
-        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard_1, sub_dashboard_2])
+        factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard_1.id, organization_id=target_org.id)
+        factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard_2.id, organization_id=target_org.id)
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id,
+            template_dashboard_id=sub_dashboard_1.id,
+            order_index=0,
+        )
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id,
+            template_dashboard_id=sub_dashboard_2.id,
+            order_index=1,
+        )
 
         result = ordered_org_assigned_subdashboard(composed_dashboard, target_org)
 
@@ -398,23 +417,35 @@ class TestDeployToTargetOrg:
         factory.create_metr_data_source_for(query.data_source, "postgres")
         target_ds = factory.create_data_source(org=target_org)
         factory.create_metr_data_source_for(target_ds, "postgres")
-        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
-        factory.create_sub_dashboard_assignment_for(sub_dashboard, target_org)
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub_dashboard.id
+        )
+        factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard.id, organization_id=target_org.id)
+        factory.create_admin(org=target_org)
 
         result = deploy_to_target_org(composed_dashboard, target_org)
 
         assert result.error is None
-        deployed = Dashboard.query.join(MetrDashboard, Dashboard.id == MetrDashboard.dashboard_id).filter(
-            MetrDashboard.url_identifier == composed_dashboard.url_identifier,
-            MetrDashboard.org_id == target_org.id,
-        ).one()
+        deployed = (
+            Dashboard.query.join(MetrDashboard, Dashboard.id == MetrDashboard.dashboard_id)
+            .filter(
+                MetrDashboard.url_identifier == composed_dashboard.url_identifier,
+                MetrDashboard.org_id == target_org.id,
+            )
+            .one()
+        )
         assert deployed.name == composed_dashboard.name
 
     def test_returns_error_on_validation_failure(self, factory, sub_dashboard, target_org):
         widget = factory.create_widget(dashboard=sub_dashboard)
         widget.visualization.query_rel.data_source.delete()
-        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
-        factory.create_sub_dashboard_assignment_for(sub_dashboard, target_org)
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub_dashboard.id
+        )
+        factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard.id, organization_id=target_org.id)
+        factory.create_admin(org=target_org)
 
         result = deploy_to_target_org(composed_dashboard, target_org)
 
@@ -434,9 +465,13 @@ class TestDeployComposedDashboard:
         for org in (target_org_1, target_org_2):
             target_ds = factory.create_data_source(org=org)
             factory.create_metr_data_source_for(target_ds, "postgres")
-            factory.create_sub_dashboard_assignment_for(sub_dashboard, org)
+            factory.create_sub_dashboard_assignment(dashboard_id=sub_dashboard.id, organization_id=org.id)
+            factory.create_admin(org=org)
 
-        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_entry(
+            composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub_dashboard.id
+        )
 
         results = deploy_composed_dashboard(composed_dashboard, [target_org_1, target_org_2])
 

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from redash.models import Dashboard, MetrDashboard, MetrQuery, Visualization, db
+from redash.models import Dashboard, MetrDashboard, MetrQuery, Query, Visualization, db
 from redash_global.deployment.deploy import (
     copy_allowed_widgets_query,
     copy_widget,
@@ -8,6 +8,7 @@ from redash_global.deployment.deploy import (
     delete_orphaned_visualizations,
     deploy_composed_dashboard,
     deploy_to_target_org,
+    execute_query_parameter_dependencies,
     get_or_copy_query,
     get_or_create_dashboard,
     get_target_data_sources,
@@ -127,9 +128,9 @@ class TestResolveQueryDropdownDependencies:
 
         assert query_options["parameters"][0]["queryId"] != dep_query.id
         copied_query_id = query_options["parameters"][0]["queryId"]
-        copied_query = db.session.query(MetrQuery).filter_by(
-            template_query_id=dep_query.id, org_id=target_org.id
-        ).one()
+        copied_query = (
+            db.session.query(MetrQuery).filter_by(template_query_id=dep_query.id, org_id=target_org.id).one()
+        )
         assert copied_query.query_id == copied_query_id
 
 
@@ -258,6 +259,62 @@ class TestGetOrCopyQuery:
         result2 = get_or_copy_query(query2, target_org, deploy_user, data_source_map, query_id_map)
 
         assert result1.options["parameters"][0]["queryId"] == result2.options["parameters"][0]["queryId"]
+
+    def test_handles_none_options_with_query_based_parameter(self, factory, target_org):
+        template_org = factory.create_org()
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(dashboard=factory.create_dashboard(org=template_org))
+        template_query = widget.visualization.query_rel
+        template_query.data_source = template_ds
+        template_query.options = None
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        assert result.options is not None
+        assert isinstance(result.options, dict)
+
+    def test_preserves_parameter_value_when_updating_query_id(self, factory, target_org):
+        template_org = factory.create_org()
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(dashboard=factory.create_dashboard(org=template_org))
+        template_query = widget.visualization.query_rel
+        template_query.data_source = template_ds
+        template_query.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id, "value": "some_value"},
+            ]
+        }
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        result = get_or_copy_query(template_query, target_org, deploy_user, data_source_map)
+
+        assert result.options["parameters"][0]["queryId"] != dep_query.id
+        assert result.options["parameters"][0]["value"] == "some_value"
 
 
 class TestCopyAllowedWidgetsQuery:
@@ -666,6 +723,46 @@ class TestDeployToTargetOrg:
         deployed_query = deployed.widgets[0].visualization.query_rel
         assert deployed_query.options["parameters"][0]["type"] == "query"
         assert deployed_query.options["parameters"][0]["queryId"] != dep_query.id
+
+
+class TestExecuteQueryParameterDependencies:
+    def test_executes_dependent_queries(self, factory, target_org):
+        template_org = factory.create_org()
+        template_ds = factory.create_data_source(org=template_org)
+        factory.create_metr_data_source_for(template_ds, "postgres")
+
+        dep_dashboard = factory.create_dashboard(org=template_org)
+        dep_widget = factory.create_widget(dashboard=dep_dashboard)
+        dep_query = dep_widget.visualization.query_rel
+        dep_query.data_source = template_ds
+
+        widget = factory.create_widget(dashboard=factory.create_dashboard(org=template_org))
+        query = widget.visualization.query_rel
+        query.data_source = template_ds
+        query.options = {
+            "parameters": [
+                {"name": "dropdown_param", "type": "query", "queryId": dep_query.id},
+            ]
+        }
+
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        data_source_map = {"postgres": target_ds}
+
+        deploy_user = factory.create_user(org=target_org)
+
+        copied_query = get_or_copy_query(query, target_org, deploy_user, data_source_map, {})
+        copied_dep_query_id = copied_query.options["parameters"][0]["queryId"]
+
+        target_dashboard = factory.create_dashboard(org=target_org)
+        visualization = factory.create_visualization(query_rel=copied_query)
+        factory.create_widget(dashboard=target_dashboard, visualization=visualization)
+        db.session.flush()
+
+        execute_query_parameter_dependencies(target_dashboard)
+
+        copied_dep_query = Query.query.get(copied_dep_query_id)
+        assert copied_dep_query is not None
 
 
 class TestDeployComposedDashboard:

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -1,14 +1,18 @@
 import pytest
 
-from redash.models import MetrQuery, Visualization, Widget
+from redash.models import Dashboard, MetrDashboard, MetrQuery, Visualization, Widget
 from redash_global.deployment.deploy import (
     copy_allowed_widgets_query,
     copy_widget,
+    create_dashboard,
     delete_orphaned_visualizations,
     get_or_copy_query,
+    get_or_create_dashboard,
     get_target_data_sources,
+    record_deployment,
     replace_widgets,
 )
+from redash_global.models import ComposedDashboardDeployment
 
 
 @pytest.fixture
@@ -270,3 +274,92 @@ class TestReplaceWidgets:
 
         rows = sorted(w.options["position"]["row"] for w in target_dashboard.widgets.all())
         assert rows == [0, 2]
+
+
+class TestCreateDashboard:
+    def test_creates_dashboard_with_metr_dashboard(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        dashboard = create_dashboard(composed_dashboard, target_org, deploy_user)
+
+        assert dashboard.name == composed_dashboard.name
+        assert dashboard.org_id == target_org.id
+        assert dashboard.user_id == deploy_user.id
+        assert dashboard.is_draft is False
+
+    def test_adds_default_group_to_dashboard(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        dashboard = create_dashboard(composed_dashboard, target_org, deploy_user)
+
+        assert dashboard.dashboard_groups[0].group_id == target_org.default_group.id
+
+    def test_creates_metr_dashboard_with_url_identifier(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        dashboard = create_dashboard(composed_dashboard, target_org, deploy_user)
+
+        metr_dashboard = MetrDashboard.query.filter_by(dashboard_id=dashboard.id).one()
+        assert metr_dashboard.url_identifier == composed_dashboard.url_identifier
+        assert metr_dashboard.org_id == target_org.id
+
+
+class TestGetOrCreateDashboard:
+    def test_creates_new_dashboard_when_none_exists(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        dashboard = get_or_create_dashboard(composed_dashboard, target_org, deploy_user, None)
+
+        assert Dashboard.query.filter_by(id=dashboard.id, org_id=target_org.id).one()
+
+    def test_updates_name_when_dashboard_exists(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        first_dashboard = create_dashboard(composed_dashboard, target_org, deploy_user)
+        first_name = first_dashboard.name
+
+        composed_dashboard.name = "Updated Name"
+
+        second_dashboard = get_or_create_dashboard(composed_dashboard, target_org, deploy_user, None)
+
+        assert second_dashboard.id == first_dashboard.id
+        assert second_dashboard.name == "Updated Name"
+        assert second_dashboard.name != first_name
+
+    def test_sets_allowed_widget_query_identifier(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        deploy_user = factory.create_user(org=target_org)
+
+        dashboard = get_or_create_dashboard(composed_dashboard, target_org, deploy_user, "allowed-query")
+
+        assert dashboard.metr_dashboard.allowed_widget_query_identifier == "allowed-query"
+
+
+class TestRecordDeployment:
+    def test_creates_new_deployment_record(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+
+        record_deployment(composed_dashboard, target_org)
+
+        deployment = ComposedDashboardDeployment.query.filter_by(
+            composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
+        ).one()
+        assert deployment.last_deployed_at is not None
+
+    def test_updates_existing_deployment_record(self, factory, target_org):
+        composed_dashboard = factory.create_composed_dashboard()
+        factory.create_composed_dashboard_deployment(
+            composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
+        )
+
+        record_deployment(composed_dashboard, target_org)
+
+        deployments = ComposedDashboardDeployment.query.filter_by(
+            composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
+        )
+        assert deployments.count() == 1

--- a/redash_global/tests/deployment/test_deploy.py
+++ b/redash_global/tests/deployment/test_deploy.py
@@ -6,9 +6,12 @@ from redash_global.deployment.deploy import (
     copy_widget,
     create_dashboard,
     delete_orphaned_visualizations,
+    deploy_composed_dashboard,
+    deploy_to_target_org,
     get_or_copy_query,
     get_or_create_dashboard,
     get_target_data_sources,
+    ordered_org_assigned_subdashboard,
     record_deployment,
     replace_widgets,
 )
@@ -363,3 +366,79 @@ class TestRecordDeployment:
             composed_dashboard_id=composed_dashboard.id, organization_id=target_org.id
         )
         assert deployments.count() == 1
+
+
+class TestOrderedOrgAssignedSubdashboard:
+    def test_returns_empty_list_when_no_assignments(self, factory, target_org):
+        sub_dashboard = factory.create_dashboard()
+        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+
+        result = ordered_org_assigned_subdashboard(composed_dashboard, target_org)
+
+        assert result == []
+
+    def test_returns_assigned_dashboards_in_order(self, factory, target_org):
+        sub_dashboard_1 = factory.create_dashboard()
+        sub_dashboard_2 = factory.create_dashboard()
+        factory.create_sub_dashboard_assignment_for(sub_dashboard_1, target_org)
+        factory.create_sub_dashboard_assignment_for(sub_dashboard_2, target_org)
+        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard_1, sub_dashboard_2])
+
+        result = ordered_org_assigned_subdashboard(composed_dashboard, target_org)
+
+        assert result == [sub_dashboard_1, sub_dashboard_2]
+
+
+class TestDeployToTargetOrg:
+    def test_creates_deployed_dashboard(self, factory, sub_dashboard, target_org):
+        factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = sub_dashboard.widgets[0].visualization.query_rel
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+        target_ds = factory.create_data_source(org=target_org)
+        factory.create_metr_data_source_for(target_ds, "postgres")
+        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+        factory.create_sub_dashboard_assignment_for(sub_dashboard, target_org)
+
+        result = deploy_to_target_org(composed_dashboard, target_org)
+
+        assert result.error is None
+        deployed = Dashboard.query.join(MetrDashboard, Dashboard.id == MetrDashboard.dashboard_id).filter(
+            MetrDashboard.url_identifier == composed_dashboard.url_identifier,
+            MetrDashboard.org_id == target_org.id,
+        ).one()
+        assert deployed.name == composed_dashboard.name
+
+    def test_returns_error_on_validation_failure(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        widget.visualization.query_rel.data_source.delete()
+        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+        factory.create_sub_dashboard_assignment_for(sub_dashboard, target_org)
+
+        result = deploy_to_target_org(composed_dashboard, target_org)
+
+        assert result.error is not None
+
+
+class TestDeployComposedDashboard:
+    def test_deploys_to_multiple_orgs(self, factory, sub_dashboard):
+        factory.create_widget(
+            dashboard=sub_dashboard, options={"position": {"row": 0, "col": 0, "sizeX": 1, "sizeY": 1}}
+        )
+        query = sub_dashboard.widgets[0].visualization.query_rel
+        factory.create_metr_data_source_for(query.data_source, "postgres")
+
+        target_org_1 = factory.create_org()
+        target_org_2 = factory.create_org()
+        for org in (target_org_1, target_org_2):
+            target_ds = factory.create_data_source(org=org)
+            factory.create_metr_data_source_for(target_ds, "postgres")
+            factory.create_sub_dashboard_assignment_for(sub_dashboard, org)
+
+        composed_dashboard = factory.create_composed_dashboard_from_templates([sub_dashboard])
+
+        results = deploy_composed_dashboard(composed_dashboard, [target_org_1, target_org_2])
+
+        assert len(results) == 2
+        assert all(r.error is None for r in results)

--- a/redash_global/tests/deployment/test_validations.py
+++ b/redash_global/tests/deployment/test_validations.py
@@ -1,7 +1,18 @@
 import pytest
 
-from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError, ParameterError
-from redash_global.deployment.validations import validate_allowed_widgets_query, validate_data_sources, validate_parameters
+from redash_global.deployment.exceptions import (
+    AllowedWidgetsQueryError,
+    DataSourceError,
+    DeploymentError,
+    DeploymentErrorGroup,
+    ParameterError,
+)
+from redash_global.deployment.validations import (
+    validate_allowed_widgets_query,
+    validate_composed_dashboard,
+    validate_data_sources,
+    validate_parameters,
+)
 
 
 @pytest.fixture
@@ -193,3 +204,51 @@ class TestParameterErrors:
         )
 
         assert validate_parameters([sub_dashboard, other_sub_dashboard]) == []
+
+
+class TestValidateComposedDashboard:
+    def test_passes_when_every_guard_passes(
+        self, factory, sub_dashboard, other_sub_dashboard, target_org, address_dashboard_level_mapping
+    ):
+        sub_dashboards = [sub_dashboard, other_sub_dashboard]
+        widgets = []
+        for dashboard in sub_dashboards:
+            factory.create_metr_dashboard(
+                dashboard_id=dashboard.id,
+                org_id=dashboard.org_id,
+                allowed_widget_query_identifier="shared-query",
+            )
+            query = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+            widgets.append(
+                factory.create_widget(
+                    dashboard=dashboard,
+                    visualization=factory.create_visualization(query_rel=query),
+                    options={"parameterMappings": address_dashboard_level_mapping},
+                )
+            )
+        factory.create_metr_data_source_for(widgets[0].visualization.query_rel.data_source, "controller")
+        factory.create_metr_data_source_for(factory.create_data_source(org=target_org), "controller")
+
+        validate_composed_dashboard(sub_dashboards, target_org)
+
+    def test_raises_an_exception_group_aggregating_every_guards_errors(
+        self, factory, sub_dashboard, other_sub_dashboard, target_org
+    ):
+        factory.create_metr_dashboard(
+            dashboard_id=sub_dashboard.id,
+            org_id=sub_dashboard.org_id,
+            allowed_widget_query_identifier="query-a",
+        )
+        factory.create_metr_dashboard(
+            dashboard_id=other_sub_dashboard.id,
+            org_id=other_sub_dashboard.org_id,
+            allowed_widget_query_identifier="query-b",
+        )
+        factory.create_widget(dashboard=sub_dashboard)
+
+        with pytest.raises(DeploymentErrorGroup) as exc_info:
+            validate_composed_dashboard([sub_dashboard, other_sub_dashboard], target_org)
+
+        errors = exc_info.value.errors
+        assert len(errors) == 2
+        assert all(isinstance(error, DeploymentError) for error in errors)

--- a/redash_global/tests/deployment/test_validations.py
+++ b/redash_global/tests/deployment/test_validations.py
@@ -1,11 +1,16 @@
 import pytest
 
-from redash_global.deployment.exceptions import DataSourceError
-from redash_global.deployment.validations import validate_data_sources
+from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError
+from redash_global.deployment.validations import validate_allowed_widgets_query, validate_data_sources
 
 
 @pytest.fixture
 def sub_dashboard(factory):
+    return factory.create_dashboard()
+
+
+@pytest.fixture
+def other_sub_dashboard(factory):
     return factory.create_dashboard()
 
 
@@ -52,3 +57,35 @@ class TestValidateDataSources:
 
         assert len(errors) == 1
         assert isinstance(errors[0], DataSourceError)
+
+
+class TestValidateAllowedWidgetsQuery:
+    def test_passes_when_none_reference_an_allowed_widgets_query(self, sub_dashboard, other_sub_dashboard):
+        assert validate_allowed_widgets_query([sub_dashboard, other_sub_dashboard]) == []
+
+    def test_passes_when_all_reference_the_same_query(self, factory, sub_dashboard, other_sub_dashboard):
+        for dashboard in (sub_dashboard, other_sub_dashboard):
+            factory.create_metr_dashboard(
+                dashboard_id=dashboard.id,
+                org_id=dashboard.org_id,
+                allowed_widget_query_identifier="shared-query",
+            )
+
+        assert validate_allowed_widgets_query([sub_dashboard, other_sub_dashboard]) == []
+
+    def test_reports_an_error_when_they_reference_different_queries(self, factory, sub_dashboard, other_sub_dashboard):
+        factory.create_metr_dashboard(
+            dashboard_id=sub_dashboard.id,
+            org_id=sub_dashboard.org_id,
+            allowed_widget_query_identifier="query-a",
+        )
+        factory.create_metr_dashboard(
+            dashboard_id=other_sub_dashboard.id,
+            org_id=other_sub_dashboard.org_id,
+            allowed_widget_query_identifier="query-b",
+        )
+
+        errors = validate_allowed_widgets_query([sub_dashboard, other_sub_dashboard])
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], AllowedWidgetsQueryError)

--- a/redash_global/tests/deployment/test_validations.py
+++ b/redash_global/tests/deployment/test_validations.py
@@ -1,0 +1,54 @@
+import pytest
+
+from redash_global.deployment.exceptions import DataSourceError
+from redash_global.deployment.validations import validate_data_sources
+
+
+@pytest.fixture
+def sub_dashboard(factory):
+    return factory.create_dashboard()
+
+
+@pytest.fixture
+def target_org(factory):
+    return factory.create_org()
+
+
+class TestValidateDataSources:
+    def test_passes_when_the_target_org_has_a_matching_identifier(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        factory.create_metr_data_source_for(widget.visualization.query_rel.data_source, "controller")
+        factory.create_metr_data_source_for(factory.create_data_source(org=target_org), "controller")
+
+        assert validate_data_sources([sub_dashboard], target_org) == []
+
+    def test_ignores_text_only_widgets(self, factory, sub_dashboard, target_org):
+        factory.create_widget(dashboard=sub_dashboard, visualization=None, text="just text")
+
+        assert validate_data_sources([sub_dashboard], target_org) == []
+
+    def test_reports_an_error_when_a_query_lost_its_data_source(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        widget.visualization.query_rel.data_source.delete()
+
+        errors = validate_data_sources([sub_dashboard], target_org)
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], DataSourceError)
+
+    def test_reports_an_error_when_the_data_source_has_no_identifier(self, factory, sub_dashboard, target_org):
+        factory.create_widget(dashboard=sub_dashboard)
+
+        errors = validate_data_sources([sub_dashboard], target_org)
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], DataSourceError)
+
+    def test_reports_an_error_when_the_target_org_has_no_matching_identifier(self, factory, sub_dashboard, target_org):
+        widget = factory.create_widget(dashboard=sub_dashboard)
+        factory.create_metr_data_source_for(widget.visualization.query_rel.data_source, "controller")
+
+        errors = validate_data_sources([sub_dashboard], target_org)
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], DataSourceError)

--- a/redash_global/tests/deployment/test_validations.py
+++ b/redash_global/tests/deployment/test_validations.py
@@ -1,7 +1,7 @@
 import pytest
 
-from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError
-from redash_global.deployment.validations import validate_allowed_widgets_query, validate_data_sources
+from redash_global.deployment.exceptions import AllowedWidgetsQueryError, DataSourceError, ParameterError
+from redash_global.deployment.validations import validate_allowed_widgets_query, validate_data_sources, validate_parameters
 
 
 @pytest.fixture
@@ -17,6 +17,11 @@ def other_sub_dashboard(factory):
 @pytest.fixture
 def target_org(factory):
     return factory.create_org()
+
+
+@pytest.fixture
+def address_dashboard_level_mapping():
+    return {"address": {"name": "address", "type": "dashboard-level", "mapTo": "address"}}
 
 
 class TestValidateDataSources:
@@ -89,3 +94,102 @@ class TestValidateAllowedWidgetsQuery:
 
         assert len(errors) == 1
         assert isinstance(errors[0], AllowedWidgetsQueryError)
+
+
+class TestParameterErrors:
+    def test_passes_with_no_dashboard_level_parameters(self, factory, sub_dashboard):
+        factory.create_widget(dashboard=sub_dashboard)
+
+        assert validate_parameters([sub_dashboard]) == []
+
+    def test_passes_when_same_name_and_type_across_sub_dashboards(
+        self, factory, sub_dashboard, other_sub_dashboard, address_dashboard_level_mapping
+    ):
+        for dashboard in (sub_dashboard, other_sub_dashboard):
+            query = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+            factory.create_widget(
+                dashboard=dashboard,
+                visualization=factory.create_visualization(query_rel=query),
+                options={"parameterMappings": address_dashboard_level_mapping},
+            )
+
+        assert validate_parameters([sub_dashboard, other_sub_dashboard]) == []
+
+    def test_a_parameter_can_be_used_by_only_one_sub_dashboard(
+        self, factory, sub_dashboard, other_sub_dashboard, address_dashboard_level_mapping
+    ):
+        with_param = sub_dashboard
+        query = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+        factory.create_widget(
+            dashboard=with_param,
+            visualization=factory.create_visualization(query_rel=query),
+            options={"parameterMappings": address_dashboard_level_mapping},
+        )
+        without_param = other_sub_dashboard
+        factory.create_widget(dashboard=without_param)
+
+        assert validate_parameters([with_param, without_param]) == []
+
+    def test_reports_an_error_when_same_name_has_different_types(
+        self, factory, sub_dashboard, other_sub_dashboard, address_dashboard_level_mapping
+    ):
+        query_text = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+        factory.create_widget(
+            dashboard=sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_text),
+            options={"parameterMappings": address_dashboard_level_mapping},
+        )
+        query_number = factory.create_query(options={"parameters": [{"name": "address", "type": "number"}]})
+        factory.create_widget(
+            dashboard=other_sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_number),
+            options={"parameterMappings": address_dashboard_level_mapping},
+        )
+
+        errors = validate_parameters([sub_dashboard, other_sub_dashboard])
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], ParameterError)
+
+    def test_fixed_from_url_is_treated_as_dashboard_level(
+        self, factory, sub_dashboard, other_sub_dashboard, address_dashboard_level_mapping
+    ):
+        query_text = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+        factory.create_widget(
+            dashboard=sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_text),
+            options={"parameterMappings": address_dashboard_level_mapping},
+        )
+        query_number = factory.create_query(options={"parameters": [{"name": "address", "type": "number"}]})
+        factory.create_widget(
+            dashboard=other_sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_number),
+            options={
+                "parameterMappings": {"address": {"name": "address", "type": "fixed-from-url", "mapTo": "address"}}
+            },
+        )
+
+        errors = validate_parameters([sub_dashboard, other_sub_dashboard])
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], ParameterError)
+
+    def test_widget_level_mappings_are_not_cross_checked(self, factory, sub_dashboard, other_sub_dashboard):
+        query_text = factory.create_query(options={"parameters": [{"name": "address", "type": "text"}]})
+        factory.create_widget(
+            dashboard=sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_text),
+            options={
+                "parameterMappings": {"address": {"name": "address", "type": "widget-level", "mapTo": "address"}}
+            },
+        )
+        query_number = factory.create_query(options={"parameters": [{"name": "address", "type": "number"}]})
+        factory.create_widget(
+            dashboard=other_sub_dashboard,
+            visualization=factory.create_visualization(query_rel=query_number),
+            options={
+                "parameterMappings": {"address": {"name": "address", "type": "widget-level", "mapTo": "address"}}
+            },
+        )
+
+        assert validate_parameters([sub_dashboard, other_sub_dashboard]) == []

--- a/redash_global/tests/factories.py
+++ b/redash_global/tests/factories.py
@@ -1,4 +1,4 @@
-from redash.models import MetrDataSource
+from redash.models import MetrDashboard, MetrDataSource
 from redash_global.models import (
     ComposedDashboard,
     ComposedDashboardDeployment,
@@ -21,6 +21,8 @@ composed_dashboard_entry_factory = ModelFactory(ComposedDashboardEntry, order_in
 composed_dashboard_deployment_factory = ModelFactory(ComposedDashboardDeployment)
 
 metr_data_source_factory = ModelFactory(MetrDataSource)
+
+metr_dashboard_factory = ModelFactory(MetrDashboard)
 
 
 class Factory(RedashFactory):
@@ -60,3 +62,6 @@ class Factory(RedashFactory):
             org_id=data_source.org_id,
             data_source_identifier=identifier,
         )
+
+    def create_metr_dashboard(self, **kwargs):
+        return metr_dashboard_factory.create(**kwargs)

--- a/redash_global/tests/factories.py
+++ b/redash_global/tests/factories.py
@@ -1,3 +1,4 @@
+from redash.models import MetrDataSource
 from redash_global.models import (
     ComposedDashboard,
     ComposedDashboardDeployment,
@@ -18,6 +19,8 @@ composed_dashboard_factory = ModelFactory(
 composed_dashboard_entry_factory = ModelFactory(ComposedDashboardEntry, order_index=0)
 
 composed_dashboard_deployment_factory = ModelFactory(ComposedDashboardDeployment)
+
+metr_data_source_factory = ModelFactory(MetrDataSource)
 
 
 class Factory(RedashFactory):
@@ -47,3 +50,13 @@ class Factory(RedashFactory):
         }
         args.update(kwargs)
         return composed_dashboard_deployment_factory.create(**args)
+
+    def create_metr_data_source(self, **kwargs):
+        return metr_data_source_factory.create(**kwargs)
+
+    def create_metr_data_source_for(self, data_source, identifier):
+        return self.create_metr_data_source(
+            data_source_id=data_source.id,
+            org_id=data_source.org_id,
+            data_source_identifier=identifier,
+        )

--- a/redash_global/tests/factories.py
+++ b/redash_global/tests/factories.py
@@ -1,4 +1,4 @@
-from redash.models import MetrDashboard, MetrDataSource, MetrQuery
+from redash.models import MetrDashboard, MetrDataSource, MetrQuery, metrWidget
 from redash_global.models import (
     ComposedDashboard,
     ComposedDashboardDeployment,
@@ -25,6 +25,8 @@ metr_data_source_factory = ModelFactory(MetrDataSource)
 metr_dashboard_factory = ModelFactory(MetrDashboard)
 
 metr_query_factory = ModelFactory(MetrQuery)
+
+metr_widget_factory = ModelFactory(metrWidget)
 
 
 class Factory(RedashFactory):
@@ -70,3 +72,6 @@ class Factory(RedashFactory):
 
     def create_metr_query(self, **kwargs):
         return metr_query_factory.create(**kwargs)
+
+    def create_metr_widget(self, **kwargs):
+        return metr_widget_factory.create(**kwargs)

--- a/redash_global/tests/factories.py
+++ b/redash_global/tests/factories.py
@@ -1,4 +1,4 @@
-from redash.models import MetrDashboard, MetrDataSource
+from redash.models import MetrDashboard, MetrDataSource, MetrQuery
 from redash_global.models import (
     ComposedDashboard,
     ComposedDashboardDeployment,
@@ -23,6 +23,8 @@ composed_dashboard_deployment_factory = ModelFactory(ComposedDashboardDeployment
 metr_data_source_factory = ModelFactory(MetrDataSource)
 
 metr_dashboard_factory = ModelFactory(MetrDashboard)
+
+metr_query_factory = ModelFactory(MetrQuery)
 
 
 class Factory(RedashFactory):
@@ -65,3 +67,6 @@ class Factory(RedashFactory):
 
     def create_metr_dashboard(self, **kwargs):
         return metr_dashboard_factory.create(**kwargs)
+
+    def create_metr_query(self, **kwargs):
+        return metr_query_factory.create(**kwargs)


### PR DESCRIPTION
NOTES: 
- This was done in a rush because i am being pressured to deploy, I would really appreciate if blockers are clearly separated from other things so that if there is no blockers i can deploy this one and then have another PR for the refactorings 🙏🏼  Thank you
- Part of this was first in other branches and then moved to a new branch with the help of claude in order to restructure commits 

Closes https://github.com/metr-systems/backlog/issues/4769

AI Disclaimer: Assisted by claude


# Summary

Implements the ability to deploy and redeploy a single composed dashboard to multiple target organizations. This includes validation of template dashboards before deployment, mapping of data sources and queries across orgs, copying and replacing widgets, and recording deployment metadata.

# Code Strategy

## Validation layer:

Please check this PR description for details about the validation layer, it is the same here https://github.com/metr-systems/redash/pull/83#issue-5120631638

## Deployment layer:

Deployment runs independently per org, one org's failure doesn't affect others or roll back already-succeeded deployments.

Per-org flow:
    - Initialization: Fetch the sub-dashboards assigned to the target org in order_index order
    - Validation: Check all sub-dashboards together for data source, widget, and parameter compatibility
    - Data source mapping: Build a map of target org data sources keyed by their identifiers
    - Query copying (allowed_widgets case): Copy the allowed_widgets_query if one exists, resolving its parameter dependencies
    - Widget lifecycle: Copy widgets from templates, adjust row positions for sub-dashboard stacking, and clean up orphaned visualisations. This does also include Query copying if the widget has a visualisation: Copy widget queries, resolving parameter dependencies for each
    - Dashboard tracking: Create or update the composed dashboard record; set allowed-widget query identifier if one exists
    - Deployment recording: Track the deployment with timestamp
    - Commit all database changes
    - Execution of parameter dependencies: Execute all query-based dropdown parameter dependencies asynchronously to cache results, ensuring dropdown parameters can be populated when the dashboard loads

## Error handling:

- Per-org isolation — one org's failure doesn't affect others or roll back already-succeeded deployments
- Atomic commits per org (rollback on DeploymentError, commit on success)
- Return a DeploymentResult list , each org has a DeploymentResult that includes errors if any
- Structured error reporting bundling validation failures

# QA

How did you test it? Keep your future self in mind to help debug things later.

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually on staging , you can check the composed dashboard deployed here https://dashboard.staging.metr.systems/new-org/dashboards/153-handlungsempfehlungen-composed?p_Liegenschaft=bdc1fbb3-8e1e-4cb0-956a-ac3003aa16e7 and for more information check commands and results here https://github.com/metr-systems/backlog/issues/4764
- [ ] N/A
