### PR TITLE
Feature/composed dashs crud and composition

### DIFF
--- a/redash_global/client/components/GlobalApplicationArea/ComposedDashboardCreate.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/ComposedDashboardCreate.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { Modal, notification } from "antd";
+
+import ComposedDashboardService from "../../services/composedDashboard";
+
+export default function ComposedDashboardCreateModal({ visible, onClose, onSuccess }) {
+  const [name, setName] = useState("");
+  const [urlIdentifier, setUrlIdentifier] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState({});
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    const newErrors = {};
+    if (!name.trim()) newErrors.name = "Name is required";
+    if (!urlIdentifier.trim()) newErrors.urlIdentifier = "URL identifier is required";
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setSaving(true);
+    ComposedDashboardService.create({ name, url_identifier: urlIdentifier })
+      .then((dashboard) => {
+        notification.success("Composed dashboard created successfully.");
+        handleClose();
+        onSuccess(dashboard.id);
+      })
+      .catch((error) => {
+        setSaving(false);
+        if (error.response?.status === 409) {
+          setErrors({ urlIdentifier: "A dashboard with this URL identifier already exists." });
+          notification.error("A dashboard with this URL identifier already exists.");
+        } else {
+          notification.error("Failed to create composed dashboard.");
+        }
+      });
+  };
+
+  const handleClose = () => {
+    setName("");
+    setUrlIdentifier("");
+    setErrors({});
+    onClose();
+  };
+
+  return (
+    <Modal
+      title="Create Composed Dashboard"
+      visible={visible}
+      onCancel={handleClose}
+      footer={null}
+      destroyOnClose
+    >
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="name">Name *</label>
+          <input
+            id="name"
+            type="text"
+            className={`form-control ${errors.name ? "error" : ""}`}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setErrors({ ...errors, name: null });
+            }}
+            placeholder="Enter dashboard name"
+          />
+          {errors.name && <span className="text-danger">{errors.name}</span>}
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="urlIdentifier">URL Identifier *</label>
+          <input
+            id="urlIdentifier"
+            type="text"
+            className={`form-control ${errors.urlIdentifier ? "error" : ""}`}
+            value={urlIdentifier}
+            onChange={(e) => {
+              setUrlIdentifier(e.target.value);
+              setErrors({ ...errors, urlIdentifier: null });
+            }}
+            placeholder="e.g. my-dashboard"
+          />
+          {errors.urlIdentifier && <span className="text-danger">{errors.urlIdentifier}</span>}
+        </div>
+
+        <div className="form-group">
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? "Creating..." : "Create"}
+          </button>
+          <button type="button" className="btn btn-default m-l-10" onClick={handleClose}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/redash_global/client/components/GlobalApplicationArea/ComposedDashboardCreate.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/ComposedDashboardCreate.jsx
@@ -32,7 +32,6 @@ export default function ComposedDashboardCreateModal({ visible, onClose, onSucce
         setSaving(false);
         if (error.response?.status === 409) {
           setErrors({ urlIdentifier: "A dashboard with this URL identifier already exists." });
-          notification.error("A dashboard with this URL identifier already exists.");
         } else {
           notification.error("Failed to create composed dashboard.");
         }

--- a/redash_global/client/components/GlobalApplicationArea/ComposedDashboardEdit.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/ComposedDashboardEdit.jsx
@@ -1,0 +1,280 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { filter, find, keyBy } from "lodash";
+
+import Button from "antd/lib/button";
+import Modal from "antd/lib/modal";
+import Select from "antd/lib/select";
+import Table from "antd/lib/table";
+import Icon from "antd/lib/icon";
+
+import Link from "@/components/Link";
+import PageHeader from "@/components/PageHeader";
+import BigMessage from "@/components/BigMessage";
+import LoadingState from "@/components/items-list/components/LoadingState";
+import notification from "@/services/notification";
+
+import ComposedDashboardService from "../../services/composedDashboard";
+import SubDashboardService from "../../services/subDashboard";
+
+function AddEntryModal({ visible, entries, subDashboards, saving, onAdd, onCancel }) {
+  const [selectedDashboardId, setSelectedDashboardId] = useState(undefined);
+
+  useEffect(() => {
+    if (visible) {
+      setSelectedDashboardId(undefined);
+    }
+  }, [visible]);
+
+  const assignedDashboardIds = useMemo(
+    () => new Set(entries.map((e) => e.template_dashboard_id)),
+    [entries]
+  );
+
+  const availableDashboards = useMemo(
+    () => filter(subDashboards, (d) => !assignedDashboardIds.has(d.id)),
+    [subDashboards, assignedDashboardIds]
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      title="Add subdashboard"
+      okText="Add"
+      okButtonProps={{ disabled: !selectedDashboardId || saving, loading: saving }}
+      cancelButtonProps={{ disabled: saving }}
+      closable={!saving}
+      maskClosable={!saving}
+      onOk={() => onAdd(selectedDashboardId)}
+      onCancel={onCancel}>
+      <Select
+        showSearch
+        optionFilterProp="children"
+        placeholder="Select a subdashboard"
+        style={{ width: "100%" }}
+        value={selectedDashboardId}
+        onChange={setSelectedDashboardId}
+        notFoundContent="No subdashboards available to add">
+        {availableDashboards.map((d) => (
+          <Select.Option key={d.id} value={d.id}>
+            {d.name}
+          </Select.Option>
+        ))}
+      </Select>
+    </Modal>
+  );
+}
+
+AddEntryModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  entries: PropTypes.arrayOf(PropTypes.object).isRequired,
+  subDashboards: PropTypes.arrayOf(PropTypes.object).isRequired,
+  saving: PropTypes.bool.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default function ComposedDashboardEdit({ composedDashboardId }) {
+  const [composedDashboard, setComposedDashboard] = useState(null);
+  const [entries, setEntries] = useState([]);
+  const [subDashboards, setSubDashboards] = useState([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [removingId, setRemovingId] = useState(null);
+
+  const subDashboardsById = useMemo(() => keyBy(subDashboards, "id"), [subDashboards]);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    Promise.all([
+      ComposedDashboardService.get(composedDashboardId),
+      ComposedDashboardService.getEntries(composedDashboardId),
+      SubDashboardService.query({ page_size: 1000 }),
+    ])
+      .then(([dashboard, dashboardEntries, subDashboardsData]) => {
+        if (!isCancelled) {
+          setComposedDashboard(dashboard);
+          setEntries(dashboardEntries);
+          setSubDashboards(subDashboardsData.results);
+          setIsLoaded(true);
+        }
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          setLoadError(error);
+          setIsLoaded(true);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [composedDashboardId]);
+
+  const handleAdd = useCallback(
+    (dashboardId) => {
+      setSaving(true);
+      ComposedDashboardService.addEntry(composedDashboardId, dashboardId)
+        .then((newEntry) => {
+          setEntries((current) => [...current, newEntry].sort((a, b) => a.order_index - b.order_index));
+          setModalVisible(false);
+        })
+        .catch(() => notification.error("Failed to add the subdashboard."))
+        .finally(() => setSaving(false));
+    },
+    [composedDashboardId]
+  );
+
+  const handleRemove = useCallback(
+    (entry) => {
+      setRemovingId(entry.id);
+      ComposedDashboardService.removeEntry(composedDashboardId, entry.id)
+        .then(() => setEntries((current) => filter(current, (e) => e.id !== entry.id)))
+        .catch(() => notification.error("Failed to remove the entry."))
+        .finally(() => setRemovingId(null));
+    },
+    [composedDashboardId]
+  );
+
+  const handleMoveUp = useCallback(
+    (entry) => {
+      const currentIndex = entries.findIndex((e) => e.id === entry.id);
+      if (currentIndex <= 0) return;
+
+      const newEntries = [...entries];
+      [newEntries[currentIndex - 1], newEntries[currentIndex]] = [
+        newEntries[currentIndex],
+        newEntries[currentIndex - 1],
+      ];
+
+      setSaving(true);
+      ComposedDashboardService.reorderEntries(
+        composedDashboardId,
+        newEntries.map((e) => e.id)
+      )
+        .then(() => setEntries(newEntries))
+        .catch(() => notification.error("Failed to reorder entries."))
+        .finally(() => setSaving(false));
+    },
+    [composedDashboardId, entries]
+  );
+
+  const handleMoveDown = useCallback(
+    (entry) => {
+      const currentIndex = entries.findIndex((e) => e.id === entry.id);
+      if (currentIndex >= entries.length - 1) return;
+
+      const newEntries = [...entries];
+      [newEntries[currentIndex], newEntries[currentIndex + 1]] = [
+        newEntries[currentIndex + 1],
+        newEntries[currentIndex],
+      ];
+
+      setSaving(true);
+      ComposedDashboardService.reorderEntries(
+        composedDashboardId,
+        newEntries.map((e) => e.id)
+      )
+        .then(() => setEntries(newEntries))
+        .catch(() => notification.error("Failed to reorder entries."))
+        .finally(() => setSaving(false));
+    },
+    [composedDashboardId, entries]
+  );
+
+  const columns = [
+    {
+      title: "Subdashboard",
+      dataIndex: "template_dashboard_id",
+      key: "name",
+      render: (dashboardId) => {
+        const dashboard = subDashboardsById[dashboardId];
+        return dashboard ? dashboard.name : `Dashboard #${dashboardId}`;
+      },
+    },
+    {
+      title: "",
+      key: "actions",
+      width: "20%",
+      className: "text-nowrap",
+      render: (text, entry) => {
+        const currentIndex = entries.findIndex((e) => e.id === entry.id);
+        return (
+          <span>
+            <Button
+              type="link"
+              disabled={currentIndex === 0 || saving}
+              onClick={() => handleMoveUp(entry)}>
+              <Icon type="arrow-up" /> Up
+            </Button>
+            <Button
+              type="link"
+              disabled={currentIndex >= entries.length - 1 || saving}
+              onClick={() => handleMoveDown(entry)}>
+              <Icon type="arrow-down" /> Down
+            </Button>
+            <Button
+              type="link"
+              danger
+              loading={removingId === entry.id}
+              disabled={removingId !== null || saving}
+              onClick={() => handleRemove(entry)}>
+              Remove
+            </Button>
+          </span>
+        );
+      },
+    },
+  ];
+
+  const title = composedDashboard ? `Edit — ${composedDashboard.name}` : "Edit Composed Dashboard";
+
+  return (
+    <div className="page-dashboard-list">
+      <div className="container">
+        <PageHeader title={title} />
+        <div className="m-b-15">
+          <Link href="composed-dashboards">&larr; Back to composed dashboards</Link>
+        </div>
+
+        {!isLoaded ? (
+          <LoadingState />
+        ) : loadError ? (
+          <BigMessage icon="fa-exclamation-circle" message="Failed to load composed dashboard." />
+        ) : (
+          <React.Fragment>
+            <div className="m-b-15">
+              <Button type="primary" onClick={() => setModalVisible(true)} disabled={saving}>
+                Add subdashboard
+              </Button>
+            </div>
+            <div className="bg-white tiled table-responsive">
+              <Table
+                rowKey="id"
+                columns={columns}
+                dataSource={entries}
+                pagination={false}
+                locale={{ emptyText: "No subdashboards added yet." }}
+              />
+            </div>
+            <AddEntryModal
+              visible={modalVisible}
+              entries={entries}
+              subDashboards={subDashboards}
+              saving={saving}
+              onAdd={handleAdd}
+              onCancel={() => setModalVisible(false)}
+            />
+          </React.Fragment>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ComposedDashboardEdit.propTypes = {
+  composedDashboardId: PropTypes.string.isRequired,
+};

--- a/redash_global/client/components/GlobalApplicationArea/ComposedDashboardList.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/ComposedDashboardList.jsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+
+import Link from "@/components/Link";
+import PageHeader from "@/components/PageHeader";
+import Paginator from "@/components/Paginator";
+import { wrap as itemsList, ControllerType } from "@/components/items-list/ItemsList";
+import { ResourceItemsSource } from "@/components/items-list/classes/ItemsSource";
+import { UrlStateStorage } from "@/components/items-list/classes/StateStorage";
+import ItemsTable, { Columns } from "@/components/items-list/components/ItemsTable";
+
+import ComposedDashboardService from "../../services/composedDashboard";
+import ComposedDashboardCreateModal from "./ComposedDashboardCreate";
+
+const listColumns = [
+  Columns.custom(
+    (text, item) => (
+      <div className="table-main-title">{item.name}</div>
+    ),
+    { title: "Name", width: null }
+  ),
+  Columns.custom((text, item) => item.url_identifier || "—", { title: "URL Identifier" }),
+  Columns.custom(
+    (text, item) => <Link href={`composed-dashboards/${item.id}/edit`}>Edit composition</Link>,
+    { title: "", width: "1%", className: "text-nowrap" }
+  ),
+  Columns.custom(
+    (text, item) => (
+      <button
+        type="button"
+        className="btn btn-xs btn-danger"
+        onClick={() => {
+          if (window.confirm(`Delete "${item.name}"?`)) {
+            ComposedDashboardService.delete(item.id).then(() => {
+              window.location.reload();
+            });
+          }
+        }}
+      >
+        Delete
+      </button>
+    ),
+    { title: "", width: "1%", className: "text-nowrap" }
+  ),
+];
+
+function ComposedDashboardList({ controller }) {
+  const [createModalVisible, setCreateModalVisible] = useState(false);
+
+  const handleCreateSuccess = (dashboardId) => {
+    setCreateModalVisible(false);
+    window.location.href = `composed-dashboards/${dashboardId}/edit`;
+  };
+
+  return (
+    <div className="page-dashboard-list">
+      <div className="container">
+        <PageHeader title={controller.params.pageTitle} />
+        <div className="m-b-15">
+          <button
+            className="btn btn-primary"
+            onClick={() => setCreateModalVisible(true)}
+          >
+            Create Composed Dashboard
+          </button>
+        </div>
+        <ComposedDashboardCreateModal
+          visible={createModalVisible}
+          onClose={() => setCreateModalVisible(false)}
+          onSuccess={handleCreateSuccess}
+        />
+        {controller.isLoaded && controller.isEmpty ? (
+          <div className="text-center">There are no composed dashboards yet.</div>
+        ) : (
+          <div className="bg-white tiled table-responsive">
+            <ItemsTable
+              items={controller.pageItems}
+              loading={!controller.isLoaded}
+              columns={listColumns}
+              orderByField={controller.orderByField}
+              orderByReverse={controller.orderByReverse}
+              toggleSorting={controller.toggleSorting}
+            />
+            <Paginator
+              showPageSizeSelect
+              totalCount={controller.totalItemsCount}
+              pageSize={controller.itemsPerPage}
+              onPageSizeChange={(itemsPerPage) => controller.updatePagination({ itemsPerPage })}
+              page={controller.page}
+              onChange={(page) => controller.updatePagination({ page })}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ComposedDashboardList.propTypes = {
+  controller: ControllerType.isRequired,
+};
+
+const ComposedDashboardListPage = itemsList(
+  ComposedDashboardList,
+  () =>
+    new ResourceItemsSource({
+      getResource() {
+        return ComposedDashboardService.query.bind(ComposedDashboardService);
+      },
+    }),
+  () => new UrlStateStorage({ orderByField: "created_at", orderByReverse: true })
+);
+
+export default ComposedDashboardListPage;

--- a/redash_global/client/components/GlobalApplicationArea/ComposedDashboardList.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/ComposedDashboardList.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Modal } from "antd";
 
 import Link from "@/components/Link";
 import PageHeader from "@/components/PageHeader";
@@ -29,11 +30,17 @@ const listColumns = [
         type="button"
         className="btn btn-xs btn-danger"
         onClick={() => {
-          if (window.confirm(`Delete "${item.name}"?`)) {
-            ComposedDashboardService.delete(item.id).then(() => {
-              window.location.reload();
-            });
-          }
+          Modal.confirm({
+            title: "Delete Dashboard",
+            content: `Are you sure you want to delete "${item.name}"?`,
+            okText: "Delete",
+            okType: "danger",
+            onOk() {
+              ComposedDashboardService.delete(item.id).then(() => {
+                window.location.reload();
+              });
+            },
+          });
         }}
       >
         Delete

--- a/redash_global/client/components/GlobalApplicationArea/GlobalDesktopNavbar.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/GlobalDesktopNavbar.jsx
@@ -30,6 +30,12 @@ export default function GlobalDesktopNavbar() {
       </NavbarSection>
 
       <NavbarSection>
+        <Menu.Item key="composed-dashboards">
+          <Link href="composed-dashboards">
+            <DesktopOutlinedIcon aria-label="Composed Dashboards navigation button" />
+            <span className="desktop-navbar-label">Composed Dashboards</span>
+          </Link>
+        </Menu.Item>
         <Menu.Item key="sub-dashboards">
           <Link href="sub-dashboards">
             <DesktopOutlinedIcon aria-label="Sub-Dashboards navigation button" />

--- a/redash_global/client/components/GlobalApplicationArea/index.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/index.jsx
@@ -8,6 +8,7 @@ import { registerComponent } from "@/components/DynamicComponent";
 
 import GlobalDesktopNavbar from "./GlobalDesktopNavbar";
 import ComposedDashboardListPage from "./ComposedDashboardList";
+import ComposedDashboardEdit from "./ComposedDashboardEdit";
 import SubDashboardListPage from "./SubDashboardList";
 import SubDashboardAssignments from "./SubDashboardAssignments";
 
@@ -27,6 +28,14 @@ const routes = [
     path: "/composed-dashboards",
     title: "Composed Dashboards",
     render: () => <ComposedDashboardListPage pageTitle="Composed Dashboards" />,
+  },
+  {
+    id: "ComposedDashboards.Edit",
+    path: "/composed-dashboards/:composedDashboardId/edit",
+    title: "Edit Composed Dashboard",
+    render: (currentRoute) => (
+      <ComposedDashboardEdit composedDashboardId={currentRoute.routeParams.composedDashboardId} />
+    ),
   },
   {
     id: "SubDashboards.List",

--- a/redash_global/client/components/GlobalApplicationArea/index.jsx
+++ b/redash_global/client/components/GlobalApplicationArea/index.jsx
@@ -7,6 +7,7 @@ import handleNavigationIntent from "@/components/ApplicationArea/handleNavigatio
 import { registerComponent } from "@/components/DynamicComponent";
 
 import GlobalDesktopNavbar from "./GlobalDesktopNavbar";
+import ComposedDashboardListPage from "./ComposedDashboardList";
 import SubDashboardListPage from "./SubDashboardList";
 import SubDashboardAssignments from "./SubDashboardAssignments";
 
@@ -20,6 +21,12 @@ const routes = [
     path: "/",
     title: "Global Admin",
     render: () => <div>Work in progress</div>,
+  },
+  {
+    id: "ComposedDashboards.List",
+    path: "/composed-dashboards",
+    title: "Composed Dashboards",
+    render: () => <ComposedDashboardListPage pageTitle="Composed Dashboards" />,
   },
   {
     id: "SubDashboards.List",

--- a/redash_global/client/services/composedDashboard.js
+++ b/redash_global/client/services/composedDashboard.js
@@ -5,6 +5,12 @@ const ComposedDashboardService = {
   get: (id) => axios.get(`composed-dashboards/${id}`),
   create: (data) => axios.post("composed-dashboards", data),
   delete: (id) => axios.delete(`composed-dashboards/${id}`),
+  getEntries: (id) => axios.get(`composed-dashboards/${id}/entries`),
+  addEntry: (id, templateDashboardId) =>
+    axios.post(`composed-dashboards/${id}/entries`, { template_dashboard_id: templateDashboardId }),
+  removeEntry: (id, entryId) => axios.delete(`composed-dashboards/${id}/entries/${entryId}`),
+  reorderEntries: (id, entryIds) =>
+    axios.post(`composed-dashboards/${id}/entries/reorder`, { entry_ids: entryIds }),
 };
 
 export default ComposedDashboardService;

--- a/redash_global/client/services/composedDashboard.js
+++ b/redash_global/client/services/composedDashboard.js
@@ -1,0 +1,10 @@
+import { axios } from "./axios";
+
+const ComposedDashboardService = {
+  query: (params) => axios.get("composed-dashboards", { params }),
+  get: (id) => axios.get(`composed-dashboards/${id}`),
+  create: (data) => axios.post("composed-dashboards", data),
+  delete: (id) => axios.delete(`composed-dashboards/${id}`),
+};
+
+export default ComposedDashboardService;

--- a/redash_global/routes.py
+++ b/redash_global/routes.py
@@ -10,6 +10,10 @@ from redash_global.views.composed_dashboards import (
     composed_dashboard_create,
     composed_dashboard_delete,
     composed_dashboard_detail,
+    composed_dashboard_entries_list,
+    composed_dashboard_entries_reorder,
+    composed_dashboard_entry_create,
+    composed_dashboard_entry_delete,
     composed_dashboards_list,
 )
 from redash_global.views.index import index_view, spa_catch_all
@@ -84,6 +88,34 @@ global_blueprint.add_url_rule(
     methods=["DELETE"],
     view_func=composed_dashboard_delete,
     endpoint="composed_dashboard_delete",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>/entries",
+    methods=["GET"],
+    view_func=composed_dashboard_entries_list,
+    endpoint="composed_dashboard_entries_list",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>/entries",
+    methods=["POST"],
+    view_func=composed_dashboard_entry_create,
+    endpoint="composed_dashboard_entry_create",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>/entries/reorder",
+    methods=["POST"],
+    view_func=composed_dashboard_entries_reorder,
+    endpoint="composed_dashboard_entries_reorder",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>/entries/<int:entry_id>",
+    methods=["DELETE"],
+    view_func=composed_dashboard_entry_delete,
+    endpoint="composed_dashboard_entry_delete",
 )
 
 # Catch-all for client-side routes (e.g. /sub-dashboards). Must be registered

--- a/redash_global/routes.py
+++ b/redash_global/routes.py
@@ -6,6 +6,12 @@ from redash_global.views.assignments import (
     assignments_list,
 )
 from redash_global.views.auth import login_page, logout_page
+from redash_global.views.composed_dashboards import (
+    composed_dashboard_create,
+    composed_dashboard_delete,
+    composed_dashboard_detail,
+    composed_dashboards_list,
+)
 from redash_global.views.index import index_view, spa_catch_all
 from redash_global.views.organizations import organizations_list
 from redash_global.views.subdashboards import sub_dashboards_list
@@ -49,6 +55,35 @@ global_blueprint.add_url_rule(
     methods=["DELETE"],
     view_func=assignment_delete,
     endpoint="assignment_delete",
+)
+
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards",
+    methods=["GET"],
+    view_func=composed_dashboards_list,
+    endpoint="composed_dashboards_list",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards",
+    methods=["POST"],
+    view_func=composed_dashboard_create,
+    endpoint="composed_dashboard_create",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>",
+    methods=["GET"],
+    view_func=composed_dashboard_detail,
+    endpoint="composed_dashboard_detail",
+)
+
+global_blueprint.add_url_rule(
+    "/global-api/composed-dashboards/<int:composed_dashboard_id>",
+    methods=["DELETE"],
+    view_func=composed_dashboard_delete,
+    endpoint="composed_dashboard_delete",
 )
 
 # Catch-all for client-side routes (e.g. /sub-dashboards). Must be registered

--- a/redash_global/tests/test_composed_dashboards.py
+++ b/redash_global/tests/test_composed_dashboards.py
@@ -1,0 +1,148 @@
+import datetime
+
+import pytest
+
+from redash_global.models import ComposedDashboard
+
+LIST_URL = "/global-api/composed-dashboards"
+
+
+@pytest.fixture
+def composed_dashboard(factory):
+    return factory.create_composed_dashboard(name="Dashboard A", url_identifier="dashboard-a")
+
+
+@pytest.fixture
+def detail_url(composed_dashboard):
+    return f"{LIST_URL}/{composed_dashboard.id}"
+
+
+def test_list_requires_authentication(client):
+    response = client.get(LIST_URL)
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_list_returns_all_composed_dashboards(admin_client, factory):
+    factory.create_composed_dashboard(name="First", url_identifier="first")
+    factory.create_composed_dashboard(name="Second", url_identifier="second")
+
+    data = admin_client.get(LIST_URL).get_json()
+
+    assert data["count"] == 2
+    assert len(data["results"]) == 2
+    names = [d["name"] for d in data["results"]]
+    assert "First" in names
+    assert "Second" in names
+
+
+def test_list_orders_newest_first(admin_client, factory):
+    factory.create_composed_dashboard(name="Older", url_identifier="older", created_at=datetime.datetime(2020, 1, 1))
+    factory.create_composed_dashboard(name="Newer", url_identifier="newer", created_at=datetime.datetime(2021, 1, 1))
+
+    data = admin_client.get(LIST_URL).get_json()
+
+    assert [d["name"] for d in data["results"]] == ["Newer", "Older"]
+
+
+def test_list_paginates(admin_client, factory):
+    for i in range(3):
+        factory.create_composed_dashboard(name=f"Dashboard {i}", url_identifier=f"dashboard-{i}")
+
+    data = admin_client.get(f"{LIST_URL}?page=1&page_size=2").get_json()
+
+    assert data["count"] == 3
+    assert len(data["results"]) == 2
+    assert data["page"] == 1
+    assert data["page_size"] == 2
+
+
+def test_list_returns_expected_fields(admin_client, factory):
+    dashboard = factory.create_composed_dashboard(name="Test Dashboard", url_identifier="test-dashboard")
+
+    data = admin_client.get(LIST_URL).get_json()
+    result = data["results"][0]
+
+    assert result["id"] == dashboard.id
+    assert result["name"] == "Test Dashboard"
+    assert result["url_identifier"] == "test-dashboard"
+    assert "created_at" in result
+    assert "updated_at" in result
+
+
+def test_detail_requires_authentication(client, composed_dashboard):
+    response = client.get(f"{LIST_URL}/{composed_dashboard.id}")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_detail_returns_composed_dashboard(admin_client, composed_dashboard):
+    response = admin_client.get(f"{LIST_URL}/{composed_dashboard.id}")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["id"] == composed_dashboard.id
+    assert data["name"] == "Dashboard A"
+    assert data["url_identifier"] == "dashboard-a"
+
+
+def test_detail_returns_404_for_missing_dashboard(admin_client):
+    response = admin_client.get(f"{LIST_URL}/999999")
+
+    assert response.status_code == 404
+
+
+def test_create_requires_authentication(client):
+    response = client.post(LIST_URL, json={"name": "Test", "url_identifier": "test"})
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_create_creates_and_returns_composed_dashboard(admin_client):
+    response = admin_client.post(LIST_URL, json={"name": "New Dashboard", "url_identifier": "new-dashboard"})
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["name"] == "New Dashboard"
+    assert data["url_identifier"] == "new-dashboard"
+    assert "id" in data
+    assert "created_at" in data
+
+    dashboard = ComposedDashboard.query.get(data["id"])
+    assert dashboard is not None
+    assert dashboard.name == "New Dashboard"
+    assert dashboard.url_identifier == "new-dashboard"
+
+
+def test_create_with_duplicate_url_identifier_fails(admin_client, composed_dashboard):
+    response = admin_client.post(
+        LIST_URL,
+        json={"name": "Another Dashboard", "url_identifier": composed_dashboard.url_identifier},
+    )
+
+    assert response.status_code >= 400
+
+
+def test_delete_requires_authentication(client, composed_dashboard):
+    response = client.delete(f"{LIST_URL}/{composed_dashboard.id}")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_delete_removes_composed_dashboard(admin_client, composed_dashboard):
+    dashboard_id = composed_dashboard.id
+
+    response = admin_client.delete(f"{LIST_URL}/{dashboard_id}")
+
+    assert response.status_code == 204
+    assert ComposedDashboard.query.get(dashboard_id) is None
+
+
+def test_delete_returns_404_for_missing_dashboard(admin_client):
+    response = admin_client.delete(f"{LIST_URL}/999999")
+
+    assert response.status_code == 404

--- a/redash_global/tests/test_composed_dashboards.py
+++ b/redash_global/tests/test_composed_dashboards.py
@@ -63,6 +63,42 @@ def test_list_paginates(admin_client, factory):
     assert data["page_size"] == 2
 
 
+def test_list_handles_invalid_page_parameter(admin_client, factory):
+    factory.create_composed_dashboard(name="Dashboard 1", url_identifier="dashboard-1")
+
+    data = admin_client.get(f"{LIST_URL}?page=invalid").get_json()
+
+    assert data["count"] == 1
+    assert data["page"] == 1
+    assert len(data["results"]) == 1
+
+
+def test_list_handles_invalid_page_size_parameter(admin_client, factory):
+    factory.create_composed_dashboard(name="Dashboard 1", url_identifier="dashboard-1")
+
+    data = admin_client.get(f"{LIST_URL}?page_size=not-a-number").get_json()
+
+    assert data["count"] == 1
+    assert data["page_size"] == 25
+    assert len(data["results"]) == 1
+
+
+def test_list_handles_negative_page(admin_client, factory):
+    factory.create_composed_dashboard(name="Dashboard 1", url_identifier="dashboard-1")
+
+    data = admin_client.get(f"{LIST_URL}?page=-1").get_json()
+
+    assert data["page"] == 1
+
+
+def test_list_handles_zero_page_size(admin_client, factory):
+    factory.create_composed_dashboard(name="Dashboard 1", url_identifier="dashboard-1")
+
+    data = admin_client.get(f"{LIST_URL}?page_size=0").get_json()
+
+    assert data["page_size"] == 1
+
+
 def test_list_returns_expected_fields(admin_client, factory):
     dashboard = factory.create_composed_dashboard(name="Test Dashboard", url_identifier="test-dashboard")
 

--- a/redash_global/tests/test_composed_dashboards.py
+++ b/redash_global/tests/test_composed_dashboards.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from redash_global.models import ComposedDashboard
+from redash_global.models import ComposedDashboard, ComposedDashboardEntry
 
 LIST_URL = "/global-api/composed-dashboards"
 
@@ -15,6 +15,11 @@ def composed_dashboard(factory):
 @pytest.fixture
 def detail_url(composed_dashboard):
     return f"{LIST_URL}/{composed_dashboard.id}"
+
+
+@pytest.fixture
+def entries_url(composed_dashboard):
+    return f"{LIST_URL}/{composed_dashboard.id}/entries"
 
 
 def test_list_requires_authentication(client):
@@ -144,5 +149,172 @@ def test_delete_removes_composed_dashboard(admin_client, composed_dashboard):
 
 def test_delete_returns_404_for_missing_dashboard(admin_client):
     response = admin_client.delete(f"{LIST_URL}/999999")
+
+    assert response.status_code == 404
+
+
+def test_entries_list_requires_authentication(client, entries_url):
+    response = client.get(entries_url)
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_entries_list_returns_entries_ordered(admin_client, factory, composed_dashboard, entries_url):
+    sub1 = factory.create_dashboard(name="Sub1")
+    sub2 = factory.create_dashboard(name="Sub2")
+
+    factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub2.id, order_index=1
+    )
+    factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub1.id, order_index=0
+    )
+
+    response = admin_client.get(entries_url)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 2
+    assert data[0]["template_dashboard_id"] == sub1.id
+    assert data[0]["order_index"] == 0
+    assert data[1]["template_dashboard_id"] == sub2.id
+    assert data[1]["order_index"] == 1
+
+
+def test_entries_list_returns_404_for_missing_dashboard(admin_client):
+    response = admin_client.get(f"{LIST_URL}/999999/entries")
+
+    assert response.status_code == 404
+
+
+def test_entry_create_requires_authentication(client, entries_url):
+    response = client.post(entries_url, json={"template_dashboard_id": 1})
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_entry_create_adds_entry(admin_client, factory, composed_dashboard, entries_url):
+    sub = factory.create_dashboard(name="Subdashboard")
+
+    response = admin_client.post(entries_url, json={"template_dashboard_id": sub.id})
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["template_dashboard_id"] == sub.id
+    assert data["order_index"] == 0
+    assert data["composed_dashboard_id"] == composed_dashboard.id
+
+    entry = ComposedDashboardEntry.query.get(data["id"])
+    assert entry is not None
+
+
+def test_entry_create_auto_increments_order_index(admin_client, factory, composed_dashboard, entries_url):
+    sub1 = factory.create_dashboard(name="Sub1")
+    sub2 = factory.create_dashboard(name="Sub2")
+
+    admin_client.post(entries_url, json={"template_dashboard_id": sub1.id})
+    response = admin_client.post(entries_url, json={"template_dashboard_id": sub2.id})
+
+    data = response.get_json()
+    assert data["order_index"] == 1
+
+
+def test_entry_create_returns_404_for_missing_dashboard(admin_client):
+    response = admin_client.post(f"{LIST_URL}/999999/entries", json={"template_dashboard_id": 1})
+
+    assert response.status_code == 404
+
+
+def test_entry_delete_requires_authentication(client, factory, composed_dashboard):
+    entry = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=factory.create_dashboard().id
+    )
+    response = client.delete(f"{LIST_URL}/{composed_dashboard.id}/entries/{entry.id}")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_entry_delete_removes_entry(admin_client, factory, composed_dashboard):
+    sub = factory.create_dashboard(name="Subdashboard")
+    entry = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub.id
+    )
+
+    response = admin_client.delete(f"{LIST_URL}/{composed_dashboard.id}/entries/{entry.id}")
+
+    assert response.status_code == 204
+    assert ComposedDashboardEntry.query.get(entry.id) is None
+
+
+def test_entry_delete_returns_404_for_missing_entry(admin_client, composed_dashboard):
+    response = admin_client.delete(f"{LIST_URL}/{composed_dashboard.id}/entries/999999")
+
+    assert response.status_code == 404
+
+
+def test_entry_delete_returns_404_for_wrong_composed_dashboard(admin_client, factory, composed_dashboard):
+    other_dashboard = factory.create_composed_dashboard(name="Other", url_identifier="other")
+    sub = factory.create_dashboard(name="Subdashboard")
+    entry = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=other_dashboard.id, template_dashboard_id=sub.id
+    )
+
+    response = admin_client.delete(f"{LIST_URL}/{composed_dashboard.id}/entries/{entry.id}")
+
+    assert response.status_code == 404
+
+
+def test_entries_reorder_requires_authentication(client, entries_url):
+    response = client.post(f"{entries_url}/reorder", json={"entry_ids": []})
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_entries_reorder_updates_order_indices(admin_client, factory, composed_dashboard, entries_url):
+    sub1 = factory.create_dashboard(name="Sub1")
+    sub2 = factory.create_dashboard(name="Sub2")
+    sub3 = factory.create_dashboard(name="Sub3")
+
+    entry1 = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub1.id, order_index=0
+    )
+    entry2 = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub2.id, order_index=1
+    )
+    entry3 = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=composed_dashboard.id, template_dashboard_id=sub3.id, order_index=2
+    )
+
+    response = admin_client.post(f"{entries_url}/reorder", json={"entry_ids": [entry3.id, entry1.id, entry2.id]})
+
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert data[0]["id"] == entry3.id
+    assert data[0]["order_index"] == 0
+    assert data[1]["id"] == entry1.id
+    assert data[1]["order_index"] == 1
+    assert data[2]["id"] == entry2.id
+    assert data[2]["order_index"] == 2
+
+
+def test_entries_reorder_returns_404_for_missing_dashboard(admin_client):
+    response = admin_client.post(f"{LIST_URL}/999999/entries/reorder", json={"entry_ids": []})
+
+    assert response.status_code == 404
+
+
+def test_entries_reorder_returns_404_for_wrong_entry(admin_client, factory, composed_dashboard):
+    other_dashboard = factory.create_composed_dashboard(name="Other", url_identifier="other")
+    sub = factory.create_dashboard(name="Subdashboard")
+    entry = factory.create_composed_dashboard_entry(
+        composed_dashboard_id=other_dashboard.id, template_dashboard_id=sub.id
+    )
+
+    response = admin_client.post(f"{LIST_URL}/{composed_dashboard.id}/entries/reorder", json={"entry_ids": [entry.id]})
 
     assert response.status_code == 404

--- a/redash_global/views/composed_dashboards.py
+++ b/redash_global/views/composed_dashboards.py
@@ -1,5 +1,6 @@
 from flask import jsonify, request
 from flask_login import login_required
+from sqlalchemy.exc import IntegrityError
 
 from redash.models import db
 from redash_global.models import ComposedDashboard, ComposedDashboardEntry
@@ -49,7 +50,11 @@ def composed_dashboard_create():
 
     composed_dashboard = ComposedDashboard(name=name, url_identifier=url_identifier)
     db.session.add(composed_dashboard)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"message": "A dashboard with this URL identifier already exists."}), 409
 
     return jsonify(serialize(composed_dashboard)), 201
 
@@ -89,7 +94,7 @@ def composed_dashboard_entry_create(composed_dashboard_id):
         .filter(ComposedDashboardEntry.composed_dashboard_id == composed_dashboard_id)
         .scalar()
     )
-    next_order = (max_order or -1) + 1
+    next_order = (max_order + 1) if max_order is not None else 0
 
     entry = ComposedDashboardEntry(
         composed_dashboard_id=composed_dashboard_id,

--- a/redash_global/views/composed_dashboards.py
+++ b/redash_global/views/composed_dashboards.py
@@ -2,7 +2,7 @@ from flask import jsonify, request
 from flask_login import login_required
 
 from redash.models import db
-from redash_global.models import ComposedDashboard
+from redash_global.models import ComposedDashboard, ComposedDashboardEntry
 
 
 def serialize(composed_dashboard):
@@ -60,3 +60,70 @@ def composed_dashboard_delete(composed_dashboard_id):
     db.session.delete(composed_dashboard)
     db.session.commit()
     return "", 204
+
+
+def serialize_entry(entry):
+    return {
+        "id": entry.id,
+        "composed_dashboard_id": entry.composed_dashboard_id,
+        "template_dashboard_id": entry.template_dashboard_id,
+        "order_index": entry.order_index,
+    }
+
+
+@login_required
+def composed_dashboard_entries_list(composed_dashboard_id):
+    composed_dashboard = ComposedDashboard.query.get_or_404(composed_dashboard_id)
+    entries = composed_dashboard.entries
+    return jsonify([serialize_entry(entry) for entry in entries])
+
+
+@login_required
+def composed_dashboard_entry_create(composed_dashboard_id):
+    ComposedDashboard.query.get_or_404(composed_dashboard_id)
+    body = request.get_json(silent=True) or {}
+    template_dashboard_id = body.get("template_dashboard_id")
+
+    max_order = (
+        db.session.query(db.func.max(ComposedDashboardEntry.order_index))
+        .filter(ComposedDashboardEntry.composed_dashboard_id == composed_dashboard_id)
+        .scalar()
+    )
+    next_order = (max_order or -1) + 1
+
+    entry = ComposedDashboardEntry(
+        composed_dashboard_id=composed_dashboard_id,
+        template_dashboard_id=template_dashboard_id,
+        order_index=next_order,
+    )
+    db.session.add(entry)
+    db.session.commit()
+
+    return jsonify(serialize_entry(entry)), 201
+
+
+@login_required
+def composed_dashboard_entry_delete(composed_dashboard_id, entry_id):
+    entry = ComposedDashboardEntry.query.filter_by(
+        id=entry_id, composed_dashboard_id=composed_dashboard_id
+    ).first_or_404()
+
+    db.session.delete(entry)
+    db.session.commit()
+    return "", 204
+
+
+@login_required
+def composed_dashboard_entries_reorder(composed_dashboard_id):
+    composed_dashboard = ComposedDashboard.query.get_or_404(composed_dashboard_id)
+    body = request.get_json(silent=True) or {}
+    entry_ids = body.get("entry_ids", [])
+
+    for order_index, entry_id in enumerate(entry_ids):
+        entry = ComposedDashboardEntry.query.filter_by(
+            id=entry_id, composed_dashboard_id=composed_dashboard_id
+        ).first_or_404()
+        entry.order_index = order_index
+
+    db.session.commit()
+    return jsonify([serialize_entry(entry) for entry in composed_dashboard.entries])

--- a/redash_global/views/composed_dashboards.py
+++ b/redash_global/views/composed_dashboards.py
@@ -1,0 +1,62 @@
+from flask import jsonify, request
+from flask_login import login_required
+
+from redash.models import db
+from redash_global.models import ComposedDashboard
+
+
+def serialize(composed_dashboard):
+    return {
+        "id": composed_dashboard.id,
+        "name": composed_dashboard.name,
+        "url_identifier": composed_dashboard.url_identifier,
+        "created_at": composed_dashboard.created_at,
+        "updated_at": composed_dashboard.updated_at,
+    }
+
+
+@login_required
+def composed_dashboards_list():
+    page = int(request.args.get("page", 1))
+    page_size = int(request.args.get("page_size", 25))
+
+    query = ComposedDashboard.query.order_by(ComposedDashboard.created_at.desc())
+
+    total = query.count()
+    composed_dashboards = query.offset((page - 1) * page_size).limit(page_size).all()
+
+    return jsonify(
+        {
+            "count": total,
+            "page": page,
+            "page_size": page_size,
+            "results": [serialize(cd) for cd in composed_dashboards],
+        }
+    )
+
+
+@login_required
+def composed_dashboard_detail(composed_dashboard_id):
+    composed_dashboard = ComposedDashboard.query.get_or_404(composed_dashboard_id)
+    return jsonify(serialize(composed_dashboard))
+
+
+@login_required
+def composed_dashboard_create():
+    body = request.get_json(silent=True) or {}
+    name = body.get("name")
+    url_identifier = body.get("url_identifier")
+
+    composed_dashboard = ComposedDashboard(name=name, url_identifier=url_identifier)
+    db.session.add(composed_dashboard)
+    db.session.commit()
+
+    return jsonify(serialize(composed_dashboard)), 201
+
+
+@login_required
+def composed_dashboard_delete(composed_dashboard_id):
+    composed_dashboard = ComposedDashboard.query.get_or_404(composed_dashboard_id)
+    db.session.delete(composed_dashboard)
+    db.session.commit()
+    return "", 204

--- a/redash_global/views/composed_dashboards.py
+++ b/redash_global/views/composed_dashboards.py
@@ -18,8 +18,17 @@ def serialize(composed_dashboard):
 
 @login_required
 def composed_dashboards_list():
-    page = int(request.args.get("page", 1))
-    page_size = int(request.args.get("page_size", 25))
+    try:
+        page = int(request.args.get("page", 1))
+        page = max(page, 1)
+    except (ValueError, TypeError):
+        page = 1
+
+    try:
+        page_size = int(request.args.get("page_size", 25))
+        page_size = max(page_size, 1)
+    except (ValueError, TypeError):
+        page_size = 25
 
     query = ComposedDashboard.query.order_by(ComposedDashboard.created_at.desc())
 


### PR DESCRIPTION
Closes https://github.com/metr-systems/backlog/issues/4754
Closes https://github.com/metr-systems/backlog/issues/4755

AI Disclaimer: Assisted by Claude, these PR is mostly crud operations and UI for it, so I generated the code and then reviewed it

## Summary

A new feature called that lets you combine multiple sub-dashboards (coming from se template dashboards) into one dashboard and manage them

- You can create a new composed dashboard from the UI

<img width="1419" height="710" alt="Screenshot 2026-08-18 at 14 59 26" src="https://github.com/user-attachments/assets/8b38923a-27e7-40c9-b939-ac2684937753" />

- You can add sub-dashboards into it from the UI

<img width="1430" height="709" alt="Screenshot 2026-08-18 at 15 00 09" src="https://github.com/user-attachments/assets/58991898-345c-4c5e-ab6d-0b95874ba6f4" />


- You can remove sub-dashboards from it from the UI
- You can change the order of the sub-dashboards in a composed dashboard "edit composition" page

<img width="1438" height="709" alt="Screenshot 2026-08-18 at 15 00 21" src="https://github.com/user-attachments/assets/e6cf5cd8-fe57-460a-a157-6de2c8a29447" />

- You can delete a composed dashboard completely
<img width="1429" height="711" alt="Screenshot 2026-08-18 at 15 00 31" src="https://github.com/user-attachments/assets/8ea91a02-609d-448a-866b-ad46eb73ed01" />


## Coding Strategy

- Started with basic save/read/delete operations for composed dashboards (the CRUD part)
- Added the ability to manage sub-dashboards inside them: adding, removing, and reordering
- Followed existing app patterns on the frontend so it looks and feels consistent with other dashboard features
- Fixed edge cases like preventing duplicate dashboard names and handling auto-increment correctly

## QA

- Unit tests (pytest)
- Manually on staging, you can check it here https://global-dashboard.staging.metr.systems/composed-dashboards , credentials are on lastpass
